### PR TITLE
fix(survey): handle associated foods with sab

### DIFF
--- a/apps/survey/src/components/handlers/standard/AssociatedFoodsPromptHandler.vue
+++ b/apps/survey/src/components/handlers/standard/AssociatedFoodsPromptHandler.vue
@@ -92,7 +92,7 @@ export default defineComponent({
   },
 
   methods: {
-    ...mapActions(useSurvey, ['updateFood', 'setFoods']),
+    ...mapActions(useSurvey, ['addFoodFlag', 'updateFood', 'setFoods']),
 
     async fetchFoodData(headers: FoodHeader[]): Promise<UserFoodData[]> {
       //TODO: Show loading
@@ -234,7 +234,6 @@ export default defineComponent({
           searchTerm: 'associated food prompt',
           portionSizeMethodIndex: hasOnePortionSizeMethod ? 0 : null,
           portionSize: null,
-          associatedFoodsComplete: false,
         };
       });
 
@@ -252,7 +251,7 @@ export default defineComponent({
         // potential circular associations.
         const linkedFoodsWithoutPrompts = linkedFoods.map((food) => ({
           ...food,
-          associatedFoodsComplete: true,
+          flags: [...new Set([...food.flags, 'associated-foods-complete'])],
         }));
 
         const parentFood = this.meals[foodIndex.mealIndex].foods[foodIndex.foodIndex];
@@ -260,21 +259,12 @@ export default defineComponent({
 
         // Order of the updates is important because any changes to the linked foods will be
         // overwritten by the update to the parent food.
-        this.updateFood({
-          foodId: parentFood.id,
-          update: { linkedFoods: newLinkedFoods },
-        });
-
-        this.updateFood({
-          foodId,
-          update: { associatedFoodsComplete: true },
-        });
+        this.updateFood({ foodId: parentFood.id, update: { linkedFoods: newLinkedFoods } });
       } else {
-        this.updateFood({
-          foodId,
-          update: { associatedFoodsComplete: true, linkedFoods },
-        });
+        this.updateFood({ foodId, update: { linkedFoods } });
       }
+
+      this.addFoodFlag(foodId, 'associated-foods-complete');
 
       this.processLinkAsMain(foodIndex);
 

--- a/apps/survey/src/components/handlers/standard/FoodSearchPromptHandler.vue
+++ b/apps/survey/src/components/handlers/standard/FoodSearchPromptHandler.vue
@@ -132,7 +132,6 @@ export default defineComponent({
         customPromptAnswers,
         flags,
         linkedFoods: [],
-        associatedFoodsComplete: false,
       };
 
       this.replaceFood({ foodId: id, food: newState });

--- a/apps/survey/src/dynamic-recall/prompt-manager.ts
+++ b/apps/survey/src/dynamic-recall/prompt-manager.ts
@@ -562,8 +562,9 @@ const checkFoodStandardConditions = (
       if (foodState.type !== 'encoded-food') return false;
       if (!foodPortionSizeComplete(foodState)) return false;
 
-      return (
-        foodState.data.associatedFoodPrompts.length !== 0 && !foodState.associatedFoodsComplete
+      return !!(
+        foodState.data.associatedFoodPrompts.length &&
+        !foodState.flags.includes('associated-foods-complete')
       );
     }
 

--- a/apps/survey/src/stores/same-as-before.ts
+++ b/apps/survey/src/stores/same-as-before.ts
@@ -36,6 +36,7 @@ export const useSameAsBefore = defineStore('same-as-before', {
       if (item.food.data.sameAsBeforeOption) return item;
 
       this.removeItem(foodCode);
+      return undefined;
     },
 
     removeItem(foodCode: string) {

--- a/apps/survey/src/util/meal-food.ts
+++ b/apps/survey/src/util/meal-food.ts
@@ -73,7 +73,7 @@ export const foodPortionSizeComplete = (food: FoodState) =>
 
 export const associatedFoodPromptsComplete = (food: FoodState) =>
   food.type === 'encoded-food' &&
-  (food.associatedFoodsComplete || !food.data.associatedFoodPrompts.length);
+  (food.flags.includes('associated-foods-complete') || !food.data.associatedFoodPrompts.length);
 
 export const encodedFoodComplete = (food: FoodState) =>
   foodPortionSizeComplete(food) && associatedFoodPromptsComplete(food);

--- a/packages/common/src/types/recall.ts
+++ b/packages/common/src/types/recall.ts
@@ -28,6 +28,8 @@ export type FoodFlag =
   | 'missing-food-complete'
   | 'portion-size-option-complete'
   | 'portion-size-method-complete'
+  | 'portion-size-method-complete'
+  | 'associated-foods-complete'
   | `${string}-acknowledged`;
 
 export type CustomPromptAnswer = string | string[] | number | number[];
@@ -241,7 +243,6 @@ export interface EncodedFood extends AbstractFoodState {
   searchTerm: string | null;
   portionSizeMethodIndex: number | null;
   portionSize: PortionSizeState | null;
-  associatedFoodsComplete: boolean;
   // brand: string[]; TODO V3?
 }
 


### PR DESCRIPTION
Handle associated foods with same as before

- prevents food to be saved as SAB prematurly when assoc food PSMs are not finished yet
- convert assoc food propery to flag
- trigger SAB check on psm finish or assoc prompt finish for no linked food cases