### PR TITLE
fix(survey): clear prompt store when edit food triggered

### DIFF
--- a/apps/api/src/services/survey/portion-size-mapper.ts
+++ b/apps/api/src/services/survey/portion-size-mapper.ts
@@ -254,7 +254,7 @@ export const portionSizeMappers: Record<
   'parent-food-portion': parentFoodPortionMapper,
   pizza: pizzaPortionMapper,
   'standard-portion': standardPortionMapper,
-  weight: genericMapper,
+  'direct-weight': genericMapper,
 };
 
 export type PortionSizeMappers = typeof portionSizeMappers;

--- a/apps/survey/src/stores/prompt.ts
+++ b/apps/survey/src/stores/prompt.ts
@@ -6,7 +6,7 @@ import type { ComponentType } from '@intake24/common/prompts';
 
 interface FoodOrMealPromptsState<T> {
   prompts: {
-    [key: number]: { [key: string]: T };
+    [key: string]: { [key: string]: T };
   };
 }
 
@@ -40,16 +40,13 @@ export function getOrCreatePromptStateStore<T extends object>(
         key: storageKey,
       },
       actions: {
-        updateState(foodOrMealId: number, promptId: string, data: T) {
+        updateState(foodOrMealId: string, promptId: string, data: T) {
           this.prompts = {
             ...this.prompts,
-            [foodOrMealId]: {
-              ...this.prompts[foodOrMealId],
-              [promptId]: data,
-            },
+            [foodOrMealId]: { ...this.prompts[foodOrMealId], [promptId]: data },
           };
         },
-        clearState(foodOrMealId: number, promptId: string) {
+        clearState(foodOrMealId: string, promptId: string) {
           if (this.prompts[foodOrMealId]?.[promptId])
             Vue.delete(this.prompts[foodOrMealId], promptId);
 

--- a/packages/common/src/prompts/prompts.ts
+++ b/packages/common/src/prompts/prompts.ts
@@ -1,7 +1,7 @@
 import type { PromptSection } from '../surveys';
-import type { LocaleTranslation } from '../types';
 import type { Actions } from './actions';
 import type { Condition } from './conditions';
+import { type LocaleTranslation, type PortionSizeMethodId, portionSizeMethods } from '../types';
 
 export type ListOption<T = string> = {
   id?: number;
@@ -51,22 +51,16 @@ export const standardComponentTypes = [
 
 export type StandardComponentType = (typeof standardComponentTypes)[number];
 
-export const portionSizeComponentTypes = [
-  'as-served-prompt',
-  'cereal-prompt',
-  'direct-weight-prompt',
-  'drink-scale-prompt',
-  'guide-image-prompt',
-  'milk-in-a-hot-drink-prompt',
-  'milk-on-cereal-prompt',
-  'missing-food-prompt',
-  'parent-food-portion-prompt',
-  'pizza-prompt',
-  'portion-size-option-prompt',
-  'standard-portion-prompt',
-] as const;
+export type PortionSizeComponentType =
+  | `${PortionSizeMethodId}-prompt`
+  | 'missing-food-prompt'
+  | 'portion-size-option-prompt';
 
-export type PortionSizeComponentType = (typeof portionSizeComponentTypes)[number];
+export const portionSizeComponentTypes = [
+  ...portionSizeMethods,
+  'missing-food',
+  'portion-size-option',
+].map((type) => `${type}-prompt`) as PortionSizeComponentType[];
 
 export type ComponentType = CustomComponentType | StandardComponentType | PortionSizeComponentType;
 
@@ -97,6 +91,11 @@ export interface PromptWithSection extends BasePrompt {
 export type ImageMap = {
   labels: boolean;
   pinchZoom: boolean;
+};
+
+export type LinkedQuantityCategory = {
+  code: string;
+  unit?: string;
 };
 
 export type Slider = {
@@ -153,7 +152,7 @@ export type Prompts = {
   'guide-image-prompt': BasePortionPrompt & {
     component: 'guide-image-prompt';
     imageMap: ImageMap;
-    linkedQuantityCategories: { code: string; unit?: string }[];
+    linkedQuantityCategories: LinkedQuantityCategory[];
   };
   'milk-in-a-hot-drink-prompt': BasePortionPrompt & {
     component: 'milk-in-a-hot-drink-prompt';

--- a/packages/common/src/types/recall.ts
+++ b/packages/common/src/types/recall.ts
@@ -202,7 +202,7 @@ export type PortionSizeStates = {
     quantity: number;
     linkedQuantity: number;
   };
-  weight: PortionSizeStateBase & { method: 'weight' };
+  'direct-weight': PortionSizeStateBase & { method: 'direct-weight' };
 };
 
 export type PortionSizeMethodId = keyof PortionSizeStates;
@@ -220,7 +220,7 @@ export const portionSizeMethods: PortionSizeMethodId[] = [
   'parent-food-portion',
   'pizza',
   'milk-in-a-hot-drink',
-  'weight',
+  'direct-weight',
 ];
 
 export interface AbstractFoodState {


### PR DESCRIPTION
Reset portion size prompt state when edit portion size action trigerred.

This was changed with https://github.com/MRC-Epid-it24/intake24/commit/427e5813934ccb93233acd611554c8e8bd89b853 to retain the state for back function, but makes the edit portion size go through each panel manually.