### PR TITLE
feat(api): Custom status codes to differentiate error types

### DIFF
--- a/apps/admin/src/util/form.ts
+++ b/apps/admin/src/util/form.ts
@@ -40,6 +40,8 @@ export type FormFields<T = Dictionary> = { [P in keyof T]: T[P] };
 
 export type Form<T = Dictionary> = FormDef<T> & FormFields<T>;
 
+const expectedFailStatusCodes = [HttpStatusCode.BadRequest, HttpStatusCode.Conflict] as const;
+
 export default <T extends object = Dictionary>(
   initData: T,
   formConfig: FormConfig<T> = {}
@@ -130,7 +132,7 @@ export default <T extends object = Dictionary>(
     onFail(err): void {
       if (axios.isAxiosError(err)) {
         const { response: { status, data = {} } = {} } = err;
-        if (status === HttpStatusCode.BadRequest && 'errors' in data)
+        if (status !== undefined && expectedFailStatusCodes.includes(status) && 'errors' in data)
           this.errors.record(data.errors);
       }
     },

--- a/apps/api/__tests__/integration/admin/locales/store.test.ts
+++ b/apps/api/__tests__/integration/admin/locales/store.test.ts
@@ -78,7 +78,7 @@ export default () => {
       await suite.sharedTests.assertRecordInserted('post', url, output, { input });
     });
 
-    it('should return 400 for duplicate id', async () => {
+    it('should return 409 for duplicate id', async () => {
       const { code } = suite.data.system.language;
 
       await suite.sharedTests.assertInvalidInput('post', url, ['code'], {
@@ -92,6 +92,7 @@ export default () => {
           prototypeLocaleId: null,
           textDirection: 'ltr',
         },
+        code: 409,
       });
     });
   });

--- a/apps/api/src/http/middleware/validation-errors.ts
+++ b/apps/api/src/http/middleware/validation-errors.ts
@@ -1,9 +1,28 @@
-import type { ValidationError } from 'express-validator';
+import type { FieldValidationError, ValidationError } from 'express-validator';
+import type {
+  AlternativeValidationError,
+  GroupedAlternativeValidationError,
+  UnknownFieldsError,
+} from 'express-validator/src/base';
 
 import type { I18nService } from '@intake24/api/services';
 import type { I18nParams } from '@intake24/i18n';
 
-function localisedTypeErrorMessage(
+export const standardErrorCodes = ['$unique', '$exists'] as const;
+
+export type StandardErrorCode = (typeof standardErrorCodes)[number];
+
+export interface ExtendedFieldValidationError extends FieldValidationError {
+  code: StandardErrorCode | null;
+}
+
+export type ExtendedValidationError =
+  | AlternativeValidationError
+  | GroupedAlternativeValidationError
+  | UnknownFieldsError
+  | ExtendedFieldValidationError;
+
+function getLocalisedTypeErrorMessage(
   type: string,
   attributePath: string,
   i18nService: I18nService,
@@ -15,37 +34,53 @@ function localisedTypeErrorMessage(
   });
 }
 
-function formatErrorMessage(message: string, attributePath: string, i18nService: I18nService) {
-  switch (message) {
+function createExtendedFieldValidationError(
+  error: FieldValidationError,
+  i18nService: I18nService
+): ExtendedFieldValidationError {
+  switch (error.msg) {
     case '$unique':
-      return localisedTypeErrorMessage('unique._', attributePath, i18nService);
+      return {
+        ...error,
+        code: error.msg,
+        msg: getLocalisedTypeErrorMessage('unique._', error.path, i18nService),
+      };
     case '$exists':
-      return localisedTypeErrorMessage('exists._', attributePath, i18nService);
+      return {
+        ...error,
+        code: error.msg,
+        msg: getLocalisedTypeErrorMessage('exists._', error.path, i18nService),
+      };
     default:
-      return message;
+      return {
+        ...error,
+        code: null,
+      };
   }
 }
 
-export function validationErrorStatusCode(errors: ValidationError[]): number {
-  for (const error of errors) {
-    switch (error.msg as string) {
-      case '$unique':
-        return 409;
-      case '$exists':
-        return 400;
-    }
+export function getValidationHttpStatus(error: ExtendedValidationError): number {
+  switch (error.type) {
+    case 'field':
+      switch (error.code) {
+        case '$unique':
+          return 409;
+        default:
+          return 400;
+      }
+    default:
+      return 400;
   }
-  return 400;
 }
 
-export function formatCustomValidationError(
+export function createExtendedValidationError(
   error: ValidationError,
   i18nService: I18nService
-): ValidationError {
-  if (error.type === 'field')
-    return {
-      ...error,
-      msg: formatErrorMessage(error.msg, error.path, i18nService),
-    };
-  else return error;
+): ExtendedValidationError {
+  switch (error.type) {
+    case 'field':
+      return createExtendedFieldValidationError(error, i18nService);
+    default:
+      return error;
+  }
 }

--- a/apps/api/src/http/middleware/validation-errors.ts
+++ b/apps/api/src/http/middleware/validation-errors.ts
@@ -1,0 +1,51 @@
+import type { ValidationError } from 'express-validator';
+
+import type { I18nService } from '@intake24/api/services';
+import type { I18nParams } from '@intake24/i18n';
+
+function localisedTypeErrorMessage(
+  type: string,
+  attributePath: string,
+  i18nService: I18nService,
+  params: I18nParams = {}
+): string {
+  return i18nService.translate(`validation.types.${type}`, {
+    attribute: i18nService.translate(`validation.attributes.${attributePath}`),
+    ...params,
+  });
+}
+
+function formatErrorMessage(message: string, attributePath: string, i18nService: I18nService) {
+  switch (message) {
+    case '$unique':
+      return localisedTypeErrorMessage('unique._', attributePath, i18nService);
+    case '$exists':
+      return localisedTypeErrorMessage('exists._', attributePath, i18nService);
+    default:
+      return message;
+  }
+}
+
+export function validationErrorStatusCode(errors: ValidationError[]): number {
+  for (const error of errors) {
+    switch (error.msg as string) {
+      case '$unique':
+        return 409;
+      case '$exists':
+        return 400;
+    }
+  }
+  return 400;
+}
+
+export function formatCustomValidationError(
+  error: ValidationError,
+  i18nService: I18nService
+): ValidationError {
+  if (error.type === 'field')
+    return {
+      ...error,
+      msg: formatErrorMessage(error.msg, error.path, i18nService),
+    };
+  else return error;
+}

--- a/apps/api/src/http/middleware/validation.ts
+++ b/apps/api/src/http/middleware/validation.ts
@@ -1,12 +1,22 @@
 import type { NextFunction, Request, Response } from 'express';
 import { validationResult } from 'express-validator';
 
+import {
+  formatCustomValidationError,
+  validationErrorStatusCode,
+} from '@intake24/api/http/middleware/validation-errors';
+
 export default (req: Request, res: Response, next: NextFunction): void => {
-  const errors = validationResult(req);
+  const { i18nService } = req.scope.cradle;
+
+  const result = validationResult(req);
+  const status = validationErrorStatusCode(result.array());
+  const errors = result.formatWith((error) => formatCustomValidationError(error, i18nService));
+
   if (errors.isEmpty()) {
     next();
     return;
   }
 
-  res.status(400).json({ errors: errors.mapped(), message: 'Invalid input' });
+  res.status(status).json({ errors: errors.mapped(), message: 'Invalid input' });
 };

--- a/apps/api/src/http/requests/admin/locales/defaults.ts
+++ b/apps/api/src/http/requests/admin/locales/defaults.ts
@@ -16,7 +16,7 @@ export const code: ParamSchema = {
   custom: {
     options: async (value, meta): Promise<void> => {
       if (!(await unique({ model: SystemLocale, condition: { field: 'code', value } })))
-        throw new Error(customTypeErrorMessage('unique._', meta));
+        throw new Error('$unique');
     },
   },
 };
@@ -42,7 +42,7 @@ export const defaults: Schema = {
             options: { where },
           }))
         )
-          throw new Error(customTypeErrorMessage('unique._', meta));
+          throw new Error('$unique');
       },
     },
   },
@@ -66,7 +66,7 @@ export const defaults: Schema = {
             options: { where },
           }))
         )
-          throw new Error(customTypeErrorMessage('unique._', meta));
+          throw new Error('$unique');
       },
     },
   },
@@ -79,7 +79,7 @@ export const defaults: Schema = {
     custom: {
       options: async (value, meta): Promise<void> => {
         const language = await Language.findOne({ where: { code: value } });
-        if (!language) throw new Error(customTypeErrorMessage('exists._', meta));
+        if (!language) throw new Error('$exists');
       },
     },
   },
@@ -92,7 +92,7 @@ export const defaults: Schema = {
     custom: {
       options: async (value, meta): Promise<void> => {
         const language = await Language.findOne({ where: { code: value } });
-        if (!language) throw new Error(customTypeErrorMessage('exists._', meta));
+        if (!language) throw new Error('$exists');
       },
     },
   },

--- a/packages/i18n/src/api/en/validation/types.ts
+++ b/packages/i18n/src/api/en/validation/types.ts
@@ -2,100 +2,100 @@ import type { LocaleMessageObject } from 'vue-i18n';
 
 const attributes: LocaleMessageObject = {
   array: {
-    _: '{attribute} must be an array.',
-    min: '{attribute} must be an array (min: {min}).',
-    max: '{attribute} must be an array (max: {max}).',
-    minMax: '{attribute} must be an array (min: {min}, max: {max}).',
-    number: '{attribute} must be an array of numbers.',
-    string: '{attribute} must be an array of string.',
-    colors: '{attribute} must be an array of colors.',
+    _: '"{attribute}" must be an array.',
+    min: '"{attribute}" must be an array (min: {min}).',
+    max: '"{attribute}" must be an array (max: {max}).',
+    minMax: '"{attribute}" must be an array (min: {min}, max: {max}).',
+    number: '"{attribute}" must be an array of numbers.',
+    string: '"{attribute}" must be an array of string.',
+    colors: '"{attribute}" must be an array of colors.',
   },
   boolean: {
-    _: '{attribute} must be a boolean (true/false).',
+    _: '"{attribute}" must be a boolean (true/false).',
   },
   cron: {
-    _: '{attribute} must be a cron entry.',
+    _: '"{attribute}" must be a cron entry.',
   },
   date: {
-    _: '{attribute} must be a date.',
+    _: '"{attribute}" must be a date.',
   },
   duplicate: {
-    _: `{attribute} can't have duplicate items.`,
+    _: `"{attribute}" can't have duplicate items.`,
   },
   float: {
-    _: '{attribute} must be a floating number.',
-    min: '{attribute} must be a floating number (min: {min}).',
-    max: '{attribute} must be a floating number (max: {max}).',
-    minMax: '{attribute} must be a floating number (min: {min}, max: {max}).',
+    _: '"{attribute}" must be a floating number.',
+    min: '"{attribute}" must be a floating number (min: {min}).',
+    max: '"{attribute}" must be a floating number (max: {max}).',
+    minMax: '"{attribute}" must be a floating number (min: {min}, max: {max}).',
   },
   exists: {
-    _: '{attribute} must be existing database record.',
+    _: '"{attribute}" must refer to an existing database record.',
   },
   either: {
     _: 'Either {one} or {two} must be filled in.',
   },
   email: {
-    _: '{attribute} must be a valid email address.',
+    _: '"{attribute}" must be a valid email address.',
   },
   file: {
-    _: '{attribute} must be a file.',
-    ext: '{attribute} has invalid file extension, expected: {ext}',
-    mime: '{attribute} has invalid mime type, expected: {mime}',
+    _: '"{attribute}" must be a file.',
+    ext: '"{attribute}" has invalid file extension, expected: {ext}',
+    mime: '"{attribute}" has invalid mime type, expected: {mime}',
   },
   in: {
-    _: '{attribute} must be allowed value.',
-    options: '{attribute} must be one of the values: {options}.',
+    _: '"{attribute}" must be allowed value.',
+    options: '"{attribute}" must be one of the values: {options}.',
   },
   int: {
-    _: '{attribute} must be an integer.',
-    min: '{attribute} must be an integer (min: {min}).',
-    max: '{attribute} must be an integer (max: {max}).',
-    minMax: '{attribute} must be an integer (min: {min}, max: {max}).',
+    _: '"{attribute}" must be an integer.',
+    min: '"{attribute}" must be an integer (min: {min}).',
+    max: '"{attribute}" must be an integer (max: {max}).',
+    minMax: '"{attribute}" must be an integer (min: {min}, max: {max}).',
   },
   jwt: {
-    _: '{attribute} must be a valid JWT.',
+    _: '"{attribute}" must be a valid JWT.',
   },
   locale: {
-    _: '{attribute} must be a valid locale code.',
+    _: '"{attribute}" must be a valid locale code.',
   },
   match: {
-    _: '{attribute} must match with {match} value.',
+    _: '"{attribute}" must match with {match} value.',
   },
   object: {
-    _: '{attribute} must be an object.',
+    _: '"{attribute}" must be an object.',
   },
   password: {
     _: 'Password must contain at least 10 chars of lower/upper chars and numbers.',
   },
   phone: {
-    _: '{attribute} must be a valid telephone number.',
+    _: '"{attribute}" must be a valid telephone number.',
   },
   regEx: {
-    _: `{attribute} is invalid.`,
+    _: `"{attribute}" is invalid.`,
   },
   safeChars: {
-    _: `{attribute} must be unique code (charset [a-zA-Z0-9-_]).`,
+    _: `"{attribute}" must be unique code (charset [a-zA-Z0-9-_]).`,
   },
   string: {
-    _: '{attribute} must be filled in.',
-    max: '{attribute} must be filled in (max: {max}).',
-    minMax: '{attribute} must be a filled in (min: {min}, max: {max}).',
+    _: '"{attribute}" must be filled in.',
+    max: '"{attribute}" must be filled in (max: {max}).',
+    minMax: '"{attribute}" must be a filled in (min: {min}, max: {max}).',
     or: {
-      array: '{attribute} must be a string or an array.',
+      array: '"{attribute}" must be a string or an array.',
     },
-    unique: '{attribute} must be a string of unique characters.',
+    unique: '"{attribute}" must be a string of unique characters.',
   },
   structure: {
-    _: '{attribute} must have valid structure.',
+    _: '"{attribute}" must have valid structure.',
   },
   terms: {
-    _: '{attribute} must be accepted.',
+    _: '"{attribute}" must be accepted.',
   },
   unique: {
-    _: 'Record with this {attribute} value already exists.',
+    _: 'A record with the same "{attribute}" value already exists.',
   },
   url: {
-    _: '{attribute} must be a valid URL.',
+    _: '"{attribute}" must be a valid URL.',
   },
 };
 


### PR DESCRIPTION
Currently the API endpoints return HTTP 400 as a catch-all error status code regardless of error type. The only information returned about the error is a localised human-friendly error message which is not useful for automated tasks using the API.

For example, if an error is caused by a duplicate record code, the application might want to react by generating and trying a new code. This is currently not possible.

The underlying issue is that the express-validator solution only allows returning a single string from custom validation code. Currently the validation code uses this string to return a localised error message for standard error types.

This patch delays the localised message lookup so that a standard error type string can also be used to generate a different HTTP status code.

An alternative solution could be to insert the error type code into the returned JSON object, but the status code seems more straightforward.