### PR TITLE
feat(api): Adding Survey Slug to the Survey Submission output

### DIFF
--- a/apps/api/src/services/admin/data-export/data-export-fields.ts
+++ b/apps/api/src/services/admin/data-export/data-export-fields.ts
@@ -120,6 +120,11 @@ const dataExportFields = () => {
         return aliases && aliases.length ? aliases[0].username : undefined;
       },
     },
+    {
+      id: 'slug',
+      label: 'Survey Slug',
+      value: ({ food }: ExportRow) => food.meal?.submission?.survey?.slug,
+    },
   ];
 
   /**

--- a/apps/api/src/services/admin/data-export/data-export.service.ts
+++ b/apps/api/src/services/admin/data-export/data-export.service.ts
@@ -16,7 +16,6 @@ import type {
   WhereOptions,
 } from '@intake24/db';
 import { NotFoundError } from '@intake24/api/http/errors';
-import { logger } from '@intake24/common-backend/services';
 import {
   Op,
   Survey,

--- a/apps/api/src/services/admin/data-export/data-export.service.ts
+++ b/apps/api/src/services/admin/data-export/data-export.service.ts
@@ -16,6 +16,7 @@ import type {
   WhereOptions,
 } from '@intake24/db';
 import { NotFoundError } from '@intake24/api/http/errors';
+import { logger } from '@intake24/common-backend/services';
 import {
   Op,
   Survey,
@@ -256,7 +257,6 @@ const dataExportService = ({
 
     const { slug, surveyScheme } = survey;
     const options = getSubmissionOptions(input);
-
     const fields = await getExportFields(surveyScheme.dataExport);
     const timestamp = formatDate(new Date(), 'yyyyMMdd-HHmmss');
     const filename = `intake24-survey-data-export-${slug}-${timestamp}.csv`;

--- a/docs/admin/surveys/schemes.md
+++ b/docs/admin/surveys/schemes.md
@@ -98,6 +98,7 @@ User custom fields are key-value pairs, set up during respondent account creatio
 
 - `surveyId` - unique survey identifier, sequence number
 - `username` - survey-unique respondent identifier attached to both user and survey record (aka `user survey alias`)
+- `slug` - unique survey slug(name) used as part of the survey URL (aka `https://intake24.org/{SLUG}/recall`)
 
 #### Submission record fields
 

--- a/packages/db/src/scopes/index.ts
+++ b/packages/db/src/scopes/index.ts
@@ -49,6 +49,7 @@ export const submissionScope = (
           { association: 'missingFoods', separate: true },
         ],
       },
+      { association: 'survey', attributes: ['id', 'slug'] },
     ],
     order: [
       ['submissionTime', 'ASC'],

--- a/packages/i18n/src/admin/en/survey-schemes.json
+++ b/packages/i18n/src/admin/en/survey-schemes.json
@@ -144,7 +144,6 @@
       "user": "User record fields",
       "userCustom": "User custom fields",
       "survey": "Survey record fields",
-      "surveyCustom": "Survey custom fields",
       "submission": "Submission fields",
       "submissionCustom": "Submission custom fields",
       "meal": "Meal record fields",

--- a/packages/i18n/src/admin/en/survey-schemes.json
+++ b/packages/i18n/src/admin/en/survey-schemes.json
@@ -144,6 +144,7 @@
       "user": "User record fields",
       "userCustom": "User custom fields",
       "survey": "Survey record fields",
+      "surveyCustom": "Survey custom fields",
       "submission": "Submission fields",
       "submissionCustom": "Submission custom fields",
       "meal": "Meal record fields",


### PR DESCRIPTION
A small change to the survey submission is adding a Survey Slug as a parameter to the output. For the sake of the external modules (a.k.a. intake24-dietician).