### PR TITLE
refactor(survey): Added option to skip a step in the Recipe Builder

### DIFF
--- a/apps/survey/src/components/elements/FoodBrowser.vue
+++ b/apps/survey/src/components/elements/FoodBrowser.vue
@@ -102,6 +102,21 @@
         >
           {{ promptI18n['missing.label'] }}
         </v-btn>
+        <v-btn
+          v-if="type === 'recipeBuilder'"
+          color="primary"
+          :disabled="missingDialog"
+          large
+          outlined
+          :title="promptI18n.browse"
+          @click.stop="skipTheStep"
+        >
+          {{
+            $t(`prompts.${type}.missing.irrelevantIngredient`, {
+              ingredient: stepName,
+            })
+          }}
+        </v-btn>
       </div>
     </component>
     <missing-food-panel
@@ -176,9 +191,14 @@ export default defineComponent({
       type: String as PropType<string | null>,
       default: '',
     },
+    stepName: {
+      type: String,
+      required: false,
+      default: '',
+    },
   },
 
-  emits: ['food-selected', 'food-missing', 'recipe-builder', 'input'],
+  emits: ['food-selected', 'food-missing', 'recipe-builder', 'input', 'food-skipped'],
 
   setup(props, ctx) {
     const { translatePrompt, type } = usePromptUtils(props, ctx);
@@ -206,6 +226,7 @@ export default defineComponent({
             'missing.description',
             'missing.report',
             'missing.tryAgain',
+            'missing.irrelevantIngredient',
           ],
           {
             back: {
@@ -371,6 +392,11 @@ export default defineComponent({
       ctx.emit('food-missing', food);
     };
 
+    const skipTheStep = () => {
+      closeInDialog();
+      ctx.emit('food-skipped', null);
+    };
+
     const recipeBuilder = () => {
       closeInDialog();
       ctx.emit('recipe-builder', recipeFood.value);
@@ -453,6 +479,7 @@ export default defineComponent({
       categorySelected,
       foodMissing,
       foodSelected,
+      skipTheStep,
       navigateBack,
       recipeBuilder,
       searchTerm,

--- a/apps/survey/src/components/prompts/portion/RecipeBuilderPrompt.vue
+++ b/apps/survey/src/components/prompts/portion/RecipeBuilderPrompt.vue
@@ -54,11 +54,13 @@
                 v-bind="{
                   localeId,
                   searchParameters,
+                  stepName: translate(step.name),
                   rootCategory: step.categoryCode,
                   prompt,
                 }"
                 @food-missing="foodMissing(index)"
                 @food-selected="(food) => foodSelected(food, index)"
+                @food-skipped="foodSkipped(index)"
               ></food-browser>
             </v-card>
           </v-expand-transition>
@@ -147,8 +149,15 @@ export default defineComponent({
       return this.recipeSteps.reduce((acc, curr) => acc && curr.confirmed === 'yes', true);
     },
 
+    atLeastOneFoodSelected(): boolean {
+      return this.recipeSteps.reduce(
+        (acc, curr) => acc || (curr.selectedFoods !== undefined && curr.selectedFoods.length > 0),
+        false
+      );
+    },
+
     isValid(): boolean {
-      return this.allConfirmed;
+      return this.allConfirmed && this.atLeastOneFoodSelected;
     },
   },
 
@@ -197,6 +206,13 @@ export default defineComponent({
     },
 
     foodMissing(ingredientIndex: number): void {},
+
+    foodSkipped(index: number): void {
+      console.log('Food Skipped', index);
+      this.activeStep = index + 1;
+      this.recipeSteps[index].confirmed = 'yes';
+      this.update();
+    },
 
     async onFoodSelected(
       stepFoods: RecipeBuilderStepState,

--- a/apps/survey/src/components/prompts/portion/RecipeBuilderPrompt.vue
+++ b/apps/survey/src/components/prompts/portion/RecipeBuilderPrompt.vue
@@ -150,10 +150,7 @@ export default defineComponent({
     },
 
     atLeastOneFoodSelected(): boolean {
-      return this.recipeSteps.reduce(
-        (acc, curr) => acc || (curr.selectedFoods !== undefined && curr.selectedFoods.length > 0),
-        false
-      );
+      return this.recipeSteps.reduce((acc, curr) => acc || !!curr.selectedFoods?.length, false);
     },
 
     isValid(): boolean {

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -59,7 +59,6 @@
     "text": "",
     "description": ""
   },
-
   "associatedFoods": {
     "name": "Associated foods",
     "text": "",
@@ -217,7 +216,6 @@
     "text": "",
     "description": ""
   },
-
   "quantity": {
     "whole": "Whole",
     "fraction": "Fraction",
@@ -385,7 +383,8 @@
       "label": "I can't find my food",
       "description": "<p>If you can't find your food in the list, try rephrasing your description in the search text box above and click 'search again'.</p><p>Or click 'Browse all foods' and explore the food categories.</p><p>If you still can't find your food, click 'Report a missing food'.</p>",
       "report": "Report a missing food",
-      "tryAgain": "OK, let me try again"
+      "tryAgain": "OK, let me try again",
+      "irrelevantIngredient": "I didn't have any {ingredient}"
     },
     "addMore": "Add more ingredients",
     "noMore": "No more ingredients"

--- a/packages/i18n/src/shared/ms/prompts.json
+++ b/packages/i18n/src/shared/ms/prompts.json
@@ -384,7 +384,8 @@
       "label": "I can't find my food",
       "description": "<p>If you can't find your food in the list, try rephrasing your description in the search text box above and click 'search again'.</p><p>Or click 'Browse all foods' and explore the food categories.</p><p>If you still can't find your food, click 'Report a missing food'.</p>",
       "report": "Report a missing food",
-      "tryAgain": "OK, let me try again"
+      "tryAgain": "OK, let me try again",
+      "irrelevantIngredient": "I didn't have any {ingredient}"
     },
     "addMore": "Add more ingredients",
     "noMore": "No more ingredients"

--- a/packages/i18n/src/shared/ta/prompts.json
+++ b/packages/i18n/src/shared/ta/prompts.json
@@ -390,7 +390,8 @@
       "label": "I can't find my food",
       "description": "<p>If you can't find your food in the list, try rephrasing your description in the search text box above and click 'search again'.</p><p>Or click 'Browse all foods' and explore the food categories.</p><p>If you still can't find your food, click 'Report a missing food'.</p>",
       "report": "Report a missing food",
-      "tryAgain": "OK, let me try again"
+      "tryAgain": "OK, let me try again",
+      "irrelevantIngredient": "I didn't have any {ingredient}"
     },
     "addMore": "Add more ingredients",
     "noMore": "No more ingredients"

--- a/packages/i18n/src/shared/zh/prompts.json
+++ b/packages/i18n/src/shared/zh/prompts.json
@@ -389,7 +389,8 @@
       "label": "I can't find my food",
       "description": "<p>If you can't find your food in the list, try rephrasing your description in the search text box above and click 'search again'.</p><p>Or click 'Browse all foods' and explore the food categories.</p><p>If you still can't find your food, click 'Report a missing food'.</p>",
       "report": "Report a missing food",
-      "tryAgain": "OK, let me try again"
+      "tryAgain": "OK, let me try again",
+      "irrelevantIngredient": "I didn't have any {ingredient}"
     },
     "addMore": "Add more ingredients",
     "noMore": "No more ingredients"


### PR DESCRIPTION
Addressed these two comments ffrom @Anila in [V4-761 ticket](https://intake24.atlassian.net/jira/software/c/projects/V4/boards/5?selectedIssue=V4-761)


1. Is it possible to add this in…The steps do not include a 'I did not have any XXX (i.e. spread). So at the moment, have to enter an item at each stage to move on.
2. Is it possible to make this bit clearer…Step 5 looks like this..I thought I could click on the highlighted bits but this wasn't the case. Within this step, you can enter as many extra fillings as you like but if you did not have any, no option to say 'did not have'. Added more fillings here but realised needed to click 'no more ingredients' to be able to move onto next step.