### PR TITLE
fix(prompt): clean stale local prompt states (V4-984)

### DIFF
--- a/apps/survey/src/stores/prompt.ts
+++ b/apps/survey/src/stores/prompt.ts
@@ -46,12 +46,20 @@ export function getOrCreatePromptStateStore<T extends object>(
             [foodOrMealId]: { ...this.prompts[foodOrMealId], [promptId]: data },
           };
         },
-        clearState(foodOrMealId: string, promptId: string) {
-          if (this.prompts[foodOrMealId]?.[promptId])
-            Vue.delete(this.prompts[foodOrMealId], promptId);
+        clearState(foodOrMealId: string | string[], promptId?: string) {
+          const ids = Array.isArray(foodOrMealId) ? foodOrMealId : [foodOrMealId];
+          if (!promptId) {
+            ids.forEach((id) => {
+              delete this.prompts[id];
+            });
+          } else {
+            ids.forEach((id) => {
+              if (this.prompts[id]?.[promptId]) Vue.delete(this.prompts[id], promptId);
+            });
+          }
 
           this.prompts = Object.fromEntries(
-            Object.entries(this.prompts).filter((e) => Object.keys(e[1]).length !== 0)
+            Object.entries(this.prompts).filter((e) => Object.keys(e[1]).length)
           );
 
           // Dispose store if it is empty


### PR DESCRIPTION
- removes out-of-sync local prompt states during food change/deletion

This seems to happen in various cases:

At the moment local prompt stores are usually cleaned once answer is committed. This is not the case at the moment for PSM stores (I think this was allowed to allow go back functionality when progressing in PSM).

However, user can take action in middle of the PSM, which has not been commit yet, which can result in invalid state due to stale local prompt store (which is then out of sync with survey state)

1) user is middle of PSM and changes the food to something else -> local PSM store if kept from original. Can result in discrepancies-only or also in error - e.g. when there is invalid standard unit not anymore on new food
2) deleting food in middle of PSM
3) deleting meal
4) can probably also happen with `back` button, if user deletes/changes foods, tries to go back, and local prompt invalid state is loaded.

