### PR TITLE
Importer option selections: Specific step/module execuition

### DIFF
--- a/apps/cli/.env-template
+++ b/apps/cli/.env-template
@@ -62,7 +62,11 @@ V4_API_BASE_URL=http://localhost:9001
 # V4_API_REFRESH_TOKEN=
 V4_API_EMAIL=admin@intake24.org
 V4_API_PASSWORD=intake24
-V4_API_COOKIE_NAME=it24a_refresh_token # Admin - it24a_refresh_token, Survey - it24s_refresh_token
+
+# Auth configuration for the cli: Cookie name and auth type
+V4_API_COOKIE_NAME=it24a_refresh_token # [Default]Admin - it24a_refresh_token, Survey - it24s_refresh_token
+V4_API_AUTH_TYPE=admin # [Default]admin, survey
+
 V4_API_MAX_CONCURRENT_REQUESTS=10
 V4_API_REQUEST_RATE_LIMIT=1
 # In milliseconds

--- a/apps/cli/.env-template
+++ b/apps/cli/.env-template
@@ -62,6 +62,7 @@ V4_API_BASE_URL=http://localhost:9001
 # V4_API_REFRESH_TOKEN=
 V4_API_EMAIL=admin@intake24.org
 V4_API_PASSWORD=intake24
+V4_API_COOKIE_NAME=it24a_refresh_token # Admin - it24a_refresh_token, Survey - it24s_refresh_token
 V4_API_MAX_CONCURRENT_REQUESTS=10
 V4_API_REQUEST_RATE_LIMIT=1
 # In milliseconds

--- a/apps/cli/src/commands/packager/import-v4-command.ts
+++ b/apps/cli/src/commands/packager/import-v4-command.ts
@@ -10,7 +10,7 @@ export interface PackageImportOptions {
   asServed?: string[];
   locale?: string[];
   onConflict?: ConflictResolutionStrategy;
-  modulesForExecution?: ImporterSpecificModulesExecutionStrategy;
+  modulesForExecution?: ImporterSpecificModulesExecutionStrategy[];
 }
 
 export default async (
@@ -24,7 +24,10 @@ export default async (
 
   const importer = new ImporterV4(apiClient, logger, inputFilePath, {
     onConflict: options.onConflict,
-    modulesForExecution: options.modulesForExecution,
+    modulesForExecution:
+      options?.modulesForExecution !== undefined
+        ? options.modulesForExecution
+        : (['all'] as ImporterSpecificModulesExecutionStrategy[]),
   });
 
   await importer.import();

--- a/apps/cli/src/commands/packager/import-v4-command.ts
+++ b/apps/cli/src/commands/packager/import-v4-command.ts
@@ -1,4 +1,7 @@
-import type { ConflictResolutionStrategy } from '@intake24/cli/commands/packager/importer-v4';
+import type {
+  ConflictResolutionStrategy,
+  ImporterSpecificModulesExecutionStrategy,
+} from '@intake24/cli/commands/packager/importer-v4';
 import { ApiClientV4, getApiClientV4EnvOptions } from '@intake24/api-client-v4';
 import { ImporterV4 } from '@intake24/cli/commands/packager/importer-v4';
 import { logger as mainLogger } from '@intake24/common-backend/services/logger';
@@ -7,6 +10,7 @@ export interface PackageImportOptions {
   asServed?: string[];
   locale?: string[];
   onConflict?: ConflictResolutionStrategy;
+  modulesForExecution?: ImporterSpecificModulesExecutionStrategy;
 }
 
 export default async (
@@ -20,6 +24,7 @@ export default async (
 
   const importer = new ImporterV4(apiClient, logger, inputFilePath, {
     onConflict: options.onConflict,
+    modulesForExecution: options.modulesForExecution,
   });
 
   await importer.import();

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -105,7 +105,7 @@ const run = async () => {
   ).choices(conflictResolutionOptions);
 
   const specificModulesExecutionOption = new Option(
-    '-m, --modules-for-execution [modules-for-execution-option]',
+    '-m, --modules-for-execution [modules-for-execution-option...]',
     'Specific modules to execute'
   ).choices(importerSpecificModulesExecutionOptions);
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -16,7 +16,10 @@ import {
   packageExportV3,
   packageImportV4,
 } from './commands';
-import { conflictResolutionOptions } from './commands/packager/importer-v4';
+import {
+  conflictResolutionOptions,
+  importerSpecificModulesExecutionOptions,
+} from './commands/packager/importer-v4';
 
 const run = async () => {
   const program = new Command();
@@ -101,7 +104,13 @@ const run = async () => {
     'Conflict resolution strategy'
   ).choices(conflictResolutionOptions);
 
+  const specificModulesExecutionOption = new Option(
+    '-m, --modules-for-execution [modules-for-execution-option]',
+    'Specific modules to execute'
+  ).choices(importerSpecificModulesExecutionOptions);
+
   conflictResolutionOption.required = true;
+  specificModulesExecutionOption.required = false;
 
   program
     .command('import-package')
@@ -109,6 +118,7 @@ const run = async () => {
     .addArgument(new Argument('<version>', 'Intake24 API version').choices(['v3', 'v4']))
     .addArgument(new Argument('<package-file>', 'Input package file path'))
     .addOption(conflictResolutionOption)
+    .addOption(specificModulesExecutionOption)
     .action(async (version, inputFilePath, options) => {
       switch (version) {
         case 'v3':

--- a/docs/cli/import-package.md
+++ b/docs/cli/import-package.md
@@ -20,7 +20,23 @@ This command allows to import a new locale/images/nutrient table from the pre-de
 - `<version>` - Intake24 API version to use. Values: **v3**, **v4**
 - `<package-file>` - Input package file path
 
-## Example
+**Do not use all in combination with other modules**
+
+## Examples
+
+### Executing all modules
+
+```
+pnpm run cli import-package -c overwrite -m all v4 /path/to/the/archived/ARCHIVED_FOLDER.zip
+```
+
+### Executing multiple modules
+
+```
+pnpm run cli import-package -c overwrite -m locales nutrients v4 /path/to/the/archived/ARCHIVED_FOLDER.zip
+```
+
+### Executing one module
 
 ```
 pnpm run cli import-package -c overwrite -m enabled-local-foods v4 /path/to/the/archived/ARCHIVED_FOLDER.zip

--- a/docs/cli/import-package.md
+++ b/docs/cli/import-package.md
@@ -1,0 +1,27 @@
+# Import food data from a portable format
+
+This command allows to import a new locale/images/nutrient table from the pre-defined portable format (archived folder). The exact format can be supplied upon request
+
+## Available options:
+
+- `-c`, `--on-conflict` - How importer should handle the conflicts. Options:
+  - skip
+  - overwrite
+  - abort
+- `-m`, `--modules-for-execution` - What steps/modules importer should execute. Options:
+  - 'enabled-local-foods'
+  - images-as-served,
+  - locales,
+  - nutrients,
+  - global-foods,
+  - local-foods,
+  - enabled-local-foods,
+  - all **[Default if not chosen otherwise]**.
+- `<version>` - Intake24 API version to use. Values: **v3**, **v4**
+- `<package-file>` - Input package file path
+
+## Example
+
+```
+pnpm run cli import-package -c overwrite -m enabled-local-foods v4 /path/to/the/archived/ARCHIVED_FOLDER.zip
+```

--- a/packages/api-client-v4/src/base-client-v4.ts
+++ b/packages/api-client-v4/src/base-client-v4.ts
@@ -10,7 +10,8 @@ import type { LoginResponse, RefreshResponse } from '@intake24/common/types/http
 import type { CredentialsV4 } from './credentials';
 import type { ApiClientOptionsV4 } from './options';
 
-const REFRESH_TOKEN_COOKIE_NAME = 'it24s_refresh_token';
+//TODO: change before pushing to dev: Temp switched to admin cookie - it24a_refresh_token, before was  it24s_refresh_token
+const REFRESH_TOKEN_COOKIE_NAME = 'it24a_refresh_token';
 const DEFAULT_MAX_CONCURRENT_REQUESTS = 10;
 const DEFAULT_REQUEST_RATE_LIMIT = 300;
 const DEFAULT_REQUEST_RATE_LIMIT_WINDOW = 5 * 60 * 1000;
@@ -112,11 +113,16 @@ export class BaseClientV4 {
 
       return this.login();
     } else {
-      const response = await this.rawClient.post<RefreshResponse>('/api/auth/refresh', undefined, {
-        headers: {
-          Cookie: serializeCookie(REFRESH_TOKEN_COOKIE_NAME, this.refreshToken ?? ''),
-        },
-      });
+      //TODO: change before pushing to dev: Temp switched to admin route
+      const response = await this.rawClient.post<RefreshResponse>(
+        '/api/admin/auth/refresh',
+        undefined,
+        {
+          headers: {
+            Cookie: serializeCookie(REFRESH_TOKEN_COOKIE_NAME, this.refreshToken ?? ''),
+          },
+        }
+      );
 
       if (response.status === HttpStatusCode.Ok) {
         this.accessToken = response.data.accessToken;
@@ -130,7 +136,7 @@ export class BaseClientV4 {
     }
   }
 
-  private async refresh(): Promise<void> {
+  async refresh(): Promise<void> {
     if (this.refreshRequest === undefined) {
       this.refreshRequest = this.refreshImpl();
       await this.refreshRequest;
@@ -169,9 +175,16 @@ export class BaseClientV4 {
 
     this.logger.debug('Signing in with email and password');
 
-    const response = await this.rawClient.post<LoginResponse>('/api/auth/login', this.credentials, {
-      headers: { 'Content-Type': 'application/json' },
-    });
+    //TODO: change before pushing to dev: Temp switched to admin route
+    const response = await this.rawClient.post<LoginResponse>(
+      '/api/admin/auth/login',
+      this.credentials,
+      {
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    this.logger.debug(`Login response: ${JSON.stringify(response.data)}`);
 
     switch (response.status) {
       case HttpStatusCode.Ok:
@@ -188,6 +201,7 @@ export class BaseClientV4 {
   }
 
   private async login() {
+    this.logger.info('Trying to logging in');
     if (this.loginRequest === undefined) {
       this.loginRequest = this.loginImpl();
       await this.loginRequest;

--- a/packages/api-client-v4/src/options.ts
+++ b/packages/api-client-v4/src/options.ts
@@ -10,6 +10,7 @@ export interface ApiClientOptionsV4 {
   requestRateLimit?: number | undefined;
   requestRateLimitWindow?: number | undefined;
   cookieName?: string | undefined;
+  authResponseUrl?: '/api/auth' | '/api/admin/auth';
 }
 
 function getRequiredEnv(key: string): string {
@@ -37,6 +38,8 @@ export function getApiClientV4EnvOptions(): ApiClientOptionsV4 {
 
   const apiBaseUrl = getRequiredEnv('V4_API_BASE_URL');
   const cookieName = process.env['V4_API_COOKIE_NAME'];
+  const authResponseUrl =
+    process.env['V4_API_AUTH_TYPE'] === 'survey' ? '/api/auth' : '/api/admin/auth';
   const refreshToken = process.env['V4_API_REFRESH_TOKEN'];
 
   const maxConcurrentRequestsEnv = process.env['V4_API_MAX_CONCURRENT_REQUESTS'];
@@ -56,6 +59,7 @@ export function getApiClientV4EnvOptions(): ApiClientOptionsV4 {
     credentials,
     refreshToken,
     cookieName,
+    authResponseUrl,
     maxConcurrentRequests,
     requestRateLimit,
     requestRateLimitWindow,

--- a/packages/api-client-v4/src/options.ts
+++ b/packages/api-client-v4/src/options.ts
@@ -9,6 +9,7 @@ export interface ApiClientOptionsV4 {
   maxConcurrentRequests?: number | undefined;
   requestRateLimit?: number | undefined;
   requestRateLimitWindow?: number | undefined;
+  cookieName?: string | undefined;
 }
 
 function getRequiredEnv(key: string): string {
@@ -35,6 +36,7 @@ export function getApiClientV4EnvOptions(): ApiClientOptionsV4 {
   }
 
   const apiBaseUrl = getRequiredEnv('V4_API_BASE_URL');
+  const cookieName = process.env['V4_API_COOKIE_NAME'];
   const refreshToken = process.env['V4_API_REFRESH_TOKEN'];
 
   const maxConcurrentRequestsEnv = process.env['V4_API_MAX_CONCURRENT_REQUESTS'];
@@ -53,6 +55,7 @@ export function getApiClientV4EnvOptions(): ApiClientOptionsV4 {
     apiBaseUrl,
     credentials,
     refreshToken,
+    cookieName,
     maxConcurrentRequests,
     requestRateLimit,
     requestRateLimitWindow,


### PR DESCRIPTION
Added option to execute a specific step of `import-package` command by adding `-m` option.

option '-m, --modules-for-execution [modules-for-execution-option]' 
List of arguments/options: 
 - 'enabled-local-foods' 
 - images-as-served, 
 - locales, 
 - nutrients, 
 - global-foods, 
 - local-foods, 
 - enabled-local-foods, 
 - all **[Default if not chosen otherwise]**.