### PR TITLE
Sandwich builder fixes v4 807

### DIFF
--- a/apps/admin/src/views/locales/recipe-foods/steps-dialog.vue
+++ b/apps/admin/src/views/locales/recipe-foods/steps-dialog.vue
@@ -213,8 +213,6 @@ export default defineComponent({
           return item;
         });
 
-      console.log(form.items);
-
       const items = await form.post<LocaleRecipeFoodSteps[]>(
         `admin/locales/${props.locale.id}/recipe-foods/${props.activeRecipeFoodId}/steps`
       );

--- a/apps/admin/src/views/locales/recipe-foods/steps-dialog.vue
+++ b/apps/admin/src/views/locales/recipe-foods/steps-dialog.vue
@@ -96,6 +96,12 @@
                     :label="$t('locales.recipe-foods.repeat')"
                     name="repeatable"
                   ></v-switch>
+                  <v-switch
+                    v-model="item.required"
+                    hide-details="auto"
+                    :label="$t('locales.recipe-foods.require')"
+                    name="required"
+                  ></v-switch>
                 </v-col>
                 <v-col cols="12" md="6">
                   <select-resource
@@ -207,6 +213,8 @@ export default defineComponent({
           return item;
         });
 
+      console.log(form.items);
+
       const items = await form.post<LocaleRecipeFoodSteps[]>(
         `admin/locales/${props.locale.id}/recipe-foods/${props.activeRecipeFoodId}/steps`
       );
@@ -225,6 +233,7 @@ export default defineComponent({
         localeId: props.locale.code,
         categoryCode: '',
         repeatable: false,
+        required: false,
       });
     };
 

--- a/apps/api/src/food-index/index.ts
+++ b/apps/api/src/food-index/index.ts
@@ -80,6 +80,7 @@ export default {
               'localeId',
               'categoryCode',
               'repeatable',
+              'required',
             ],
           },
           {

--- a/apps/api/src/http/controllers/admin/locales/recipe-foods.controller.ts
+++ b/apps/api/src/http/controllers/admin/locales/recipe-foods.controller.ts
@@ -65,7 +65,11 @@ const localeRecipeFoodsController = ({ localeService }: Pick<IoC, 'localeService
 
   // adding/modifying/deleting new or existing recipe food steps for the specific recipe food for the specified Locale ID
   const setSteps = async (
-    req: Request<{ localeId: string; recipeFoodId: string }, any, LocaleRecipeFoodStepsInput[]>,
+    req: Request<
+      { localeId: string; recipeFoodId: string },
+      any,
+      { items: LocaleRecipeFoodStepsInput[] }
+    >,
     res: Response<LocaleRecipeFoodSteps[]>
   ): Promise<void> => {
     const { body } = req;
@@ -77,7 +81,11 @@ const localeRecipeFoodsController = ({ localeService }: Pick<IoC, 'localeService
       where: { id: localeId },
     });
 
-    const recipeFoodSteps = await localeService.setRecipeFoodSteps(locale, recipeFoodId, body);
+    const recipeFoodSteps = await localeService.setRecipeFoodSteps(
+      locale,
+      recipeFoodId,
+      body.items
+    );
 
     res.json(recipeFoodSteps);
   };

--- a/apps/api/src/http/requests/admin/locales/recipe-foods-steps.ts
+++ b/apps/api/src/http/requests/admin/locales/recipe-foods-steps.ts
@@ -4,9 +4,9 @@ import { validate } from '@intake24/api/http/requests/util';
 
 export default validate(
   body()
-    .custom((value: any[]) => {
+    .custom((value: { items: any[] }) => {
       if (
-        value.some(
+        value.items.some(
           ({
             id,
             recipeFoodsId,
@@ -17,6 +17,7 @@ export default validate(
             order,
             categoryCode,
             repeatable,
+            required,
           }) =>
             (typeof id !== 'undefined' && typeof id !== 'string') ||
             (typeof recipeFoodsId !== 'number' && typeof recipeFoodsId !== 'string') ||
@@ -26,12 +27,13 @@ export default validate(
             (typeof name !== 'object' && typeof name !== 'string') ||
             (typeof description !== 'object' && typeof description !== 'string') ||
             typeof categoryCode !== 'string' ||
-            typeof repeatable !== 'boolean'
+            typeof repeatable !== 'boolean' ||
+            typeof required !== 'boolean'
         )
       )
         return false;
 
       return true;
     })
-    .withMessage('Invalid Recipe Food Steps object')
+    .withMessage(`Invalid Recipe Food Steps object`)
 );

--- a/apps/api/src/services/admin/locale.service.ts
+++ b/apps/api/src/services/admin/locale.service.ts
@@ -265,6 +265,7 @@ const localeService = ({ scheduler }: Pick<IoC, 'scheduler'>) => {
         categoryCode,
         order,
         repeatable,
+        required: false,
       });
       newRecords.push(newRecord);
     }

--- a/apps/api/src/services/admin/locale.service.ts
+++ b/apps/api/src/services/admin/locale.service.ts
@@ -1,3 +1,5 @@
+import { log } from 'console';
+
 import type { IoC } from '@intake24/api/ioc';
 import type { QueueJob } from '@intake24/common/types';
 import type {
@@ -9,6 +11,7 @@ import type {
 } from '@intake24/common/types/http/admin';
 import { NotFoundError } from '@intake24/api/http/errors';
 import { addDollarSign } from '@intake24/api/util';
+import { logger } from '@intake24/common-backend/services';
 import {
   Op,
   RecipeFoods,
@@ -224,6 +227,8 @@ const localeService = ({ scheduler }: Pick<IoC, 'scheduler'>) => {
     recipeFoodSteps: LocaleRecipeFoodStepsInput[]
   ) => {
     const { code: localeCode } = await resolveLocale(localeId);
+    logger.info(`setRecipeFoodSteps: ${localeCode} ${recipeFoodId}`);
+    logger.info(JSON.stringify(recipeFoodSteps));
     const ids = recipeFoodSteps.map(({ id }) => id) as string[];
     await RecipeFoodsSteps.destroy({
       where: { localeId: localeCode, recipeFoodsId: recipeFoodId, id: { [Op.notIn]: ids } },
@@ -238,7 +243,8 @@ const localeService = ({ scheduler }: Pick<IoC, 'scheduler'>) => {
     const newRecords: RecipeFoodsSteps[] = [];
 
     for (const recipeFoodStep of recipeFoodSteps) {
-      const { id, code, name, description, categoryCode, order, repeatable } = recipeFoodStep;
+      const { id, code, name, description, categoryCode, order, repeatable, required } =
+        recipeFoodStep;
 
       if (id) {
         const match = records.find((record) => record.id === id);
@@ -251,6 +257,7 @@ const localeService = ({ scheduler }: Pick<IoC, 'scheduler'>) => {
             localeId: localeCode,
             order,
             repeatable,
+            required,
           });
           continue;
         }

--- a/apps/api/src/services/admin/locale.service.ts
+++ b/apps/api/src/services/admin/locale.service.ts
@@ -227,8 +227,6 @@ const localeService = ({ scheduler }: Pick<IoC, 'scheduler'>) => {
     recipeFoodSteps: LocaleRecipeFoodStepsInput[]
   ) => {
     const { code: localeCode } = await resolveLocale(localeId);
-    logger.info(`setRecipeFoodSteps: ${localeCode} ${recipeFoodId}`);
-    logger.info(JSON.stringify(recipeFoodSteps));
     const ids = recipeFoodSteps.map(({ id }) => id) as string[];
     await RecipeFoodsSteps.destroy({
       where: { localeId: localeCode, recipeFoodsId: recipeFoodId, id: { [Op.notIn]: ids } },

--- a/apps/api/src/services/admin/locale.service.ts
+++ b/apps/api/src/services/admin/locale.service.ts
@@ -1,5 +1,3 @@
-import { log } from 'console';
-
 import type { IoC } from '@intake24/api/ioc';
 import type { QueueJob } from '@intake24/common/types';
 import type {
@@ -11,7 +9,6 @@ import type {
 } from '@intake24/common/types/http/admin';
 import { NotFoundError } from '@intake24/api/http/errors';
 import { addDollarSign } from '@intake24/api/util';
-import { logger } from '@intake24/common-backend/services';
 import {
   Op,
   RecipeFoods,

--- a/apps/survey/src/components/elements/FoodBrowser.vue
+++ b/apps/survey/src/components/elements/FoodBrowser.vue
@@ -100,7 +100,8 @@
           {{ promptI18n['missing.label'] }}
         </v-btn>
         <v-btn
-          v-if="type === 'recipeBuilder'"
+          v-if="type === 'recipeBuilder' && !requiredToFill"
+          class="overflow-button"
           color="primary"
           :disabled="missingDialog"
           large
@@ -190,6 +191,11 @@ export default defineComponent({
       type: String,
       required: false,
       default: '',
+    },
+    requiredToFill: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
 
@@ -481,4 +487,11 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss"></style>
+<style lang="scss">
+.overflow-button {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+</style>

--- a/apps/survey/src/components/elements/FoodBrowser.vue
+++ b/apps/survey/src/components/elements/FoodBrowser.vue
@@ -208,6 +208,7 @@ export default defineComponent({
 
         return last.name;
       }
+      //add conditional browse
 
       return {
         ...translatePrompt(
@@ -226,6 +227,7 @@ export default defineComponent({
           {
             back: { category: backCategoryLabel() },
             'missing.irrelevantIngredient': { ingredient: props.stepName },
+            browse: { category: props.stepName },
           }
         ),
       };

--- a/apps/survey/src/components/elements/MissingAllRecipeIngredients.vue
+++ b/apps/survey/src/components/elements/MissingAllRecipeIngredients.vue
@@ -1,0 +1,48 @@
+<template>
+  <v-expand-transition>
+    <v-card v-show="value" ref="card" class="my-4" color="red lighten-4" outlined>
+      <v-card-text class="px-6"> {{ message }} </v-card-text>
+    </v-card>
+  </v-expand-transition>
+</template>
+
+<script lang="ts">
+import type { TranslateResult } from 'vue-i18n';
+import type { VCard } from 'vuetify/lib';
+import { defineComponent, ref, watch } from 'vue';
+
+export default defineComponent({
+  name: 'MissingAllRecipeIngridients',
+
+  props: {
+    message: {
+      type: String as () => TranslateResult,
+      required: true,
+    },
+    value: {
+      type: Boolean,
+      required: true,
+    },
+  },
+
+  setup(props) {
+    const card = ref<InstanceType<typeof VCard>>();
+    watch(
+      () => props.value,
+      (value) => {
+        if (!value) return;
+
+        setTimeout(async () => {
+          if (!card.value) return;
+
+          await card.value.$vuetify.goTo(card.value.$el as HTMLElement, { duration: 1000 });
+        }, 100);
+      }
+    );
+
+    return { card };
+  },
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/apps/survey/src/components/elements/index.ts
+++ b/apps/survey/src/components/elements/index.ts
@@ -5,6 +5,7 @@ export { default as FoodBrowser } from './FoodBrowser.vue';
 export { default as FoodSearchResults } from './FoodSearchResults.vue';
 export { default as ImagePlaceholder } from './ImagePlaceholder.vue';
 export { default as InfoAlert } from './InfoAlert.vue';
+export { default as MissingAllRecipeIngredients } from './MissingAllRecipeIngredients.vue';
 export { default as MissingFoodPanel } from './MissingFoodPanel.vue';
 export { default as SelectedFoodList } from './SelectedFoodList.vue';
 export { default as SurveyProgressBar } from './SurveyProgressBar.vue';

--- a/apps/survey/src/components/handlers/portion-size/RecipeBuilderPromptHandler.vue
+++ b/apps/survey/src/components/handlers/portion-size/RecipeBuilderPromptHandler.vue
@@ -41,6 +41,7 @@ const initialPromptState = (step: RecipeFoodStepsType): RecipeBuilderStepState =
   description: step.description,
   name: step.name,
   categoryCode: step.categoryCode,
+  required: step.required,
 });
 
 export default defineComponent({

--- a/apps/survey/src/components/prompts/portion/RecipeBuilderPrompt.vue
+++ b/apps/survey/src/components/prompts/portion/RecipeBuilderPrompt.vue
@@ -55,6 +55,7 @@
                   localeId,
                   searchParameters,
                   stepName: translate(step.name),
+                  requiredToFill: step.required,
                   rootCategory: step.categoryCode,
                   prompt,
                 }"

--- a/apps/survey/src/components/prompts/portion/RecipeBuilderPrompt.vue
+++ b/apps/survey/src/components/prompts/portion/RecipeBuilderPrompt.vue
@@ -140,12 +140,10 @@ export default defineComponent({
 
   setup() {
     const { translate } = useI18n();
-    const missingAllIngridientsDialog = ref(true);
 
     return {
       isStepValid,
       translate,
-      missingAllIngridientsDialog,
     };
   },
 

--- a/apps/survey/src/components/prompts/portion/RecipeBuilderPrompt.vue
+++ b/apps/survey/src/components/prompts/portion/RecipeBuilderPrompt.vue
@@ -68,6 +68,13 @@
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
+    <missing-all-recipe-ingredients
+      v-bind="{
+        value: allConfirmed && !atLeastOneFoodSelected,
+        message: $t('prompts.recipeBuilder.missingAllIngredients'),
+      }"
+      :class="{ 'mt-4': isMobile }"
+    ></missing-all-recipe-ingredients>
     <template #actions>
       <next :disabled="!isValid" @click="updateStepsIngredients"></next>
     </template>
@@ -79,7 +86,7 @@
 
 <script lang="ts">
 import type { PropType } from 'vue';
-import { defineComponent, set } from 'vue';
+import { defineComponent, ref, set } from 'vue';
 
 import type {
   PromptStates,
@@ -92,6 +99,7 @@ import { useI18n } from '@intake24/i18n';
 import {
   ExpansionPanelActions,
   FoodBrowser,
+  MissingAllRecipeIngredients,
   SelectedFoodList,
 } from '@intake24/survey/components/elements';
 import { foodsService } from '@intake24/survey/services';
@@ -109,7 +117,7 @@ const getNextStep = (steps: RecipeBuilderStepState[]) =>
 export default defineComponent({
   name: 'RecipeBuilderPrompt',
 
-  components: { ExpansionPanelActions, FoodBrowser, SelectedFoodList },
+  components: { ExpansionPanelActions, FoodBrowser, SelectedFoodList, MissingAllRecipeIngredients },
 
   mixins: [createBasePrompt<'recipe-builder-prompt', RecipeBuilder>()],
 
@@ -132,10 +140,12 @@ export default defineComponent({
 
   setup() {
     const { translate } = useI18n();
+    const missingAllIngridientsDialog = ref(true);
 
     return {
       isStepValid,
       translate,
+      missingAllIngridientsDialog,
     };
   },
 

--- a/packages/common/src/prompts/prompt-states.ts
+++ b/packages/common/src/prompts/prompt-states.ts
@@ -38,6 +38,7 @@ export type RecipeBuilderStepState = {
   name: RequiredLocaleTranslation;
   categoryCode: string;
   repeat: boolean;
+  required: boolean;
 };
 
 export type PromptStates = {

--- a/packages/common/src/types/foods.ts
+++ b/packages/common/src/types/foods.ts
@@ -34,4 +34,5 @@ export type RecipeFoodStepsType = {
   localeId: string;
   categoryCode: string;
   repeatable: boolean;
+  required: boolean;
 };

--- a/packages/db/sequelize/foods/migrations/20240108141241-recipe-foods-required-parameter.js
+++ b/packages/db/sequelize/foods/migrations/20240108141241-recipe-foods-required-parameter.js
@@ -1,0 +1,16 @@
+module.exports = {
+  up: (queryInterface, Sequelize) =>
+    queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn(
+        'recipe_foods_steps',
+        'required',
+        { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+        { transaction }
+      );
+    }),
+
+  down: (queryInterface, Sequelize) =>
+    queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeColumn('recipe_foods_steps', 'required', { transaction });
+    }),
+};

--- a/packages/db/sequelize/foods/seeders/v3-recipe-foods.js
+++ b/packages/db/sequelize/foods/seeders/v3-recipe-foods.js
@@ -12,6 +12,7 @@ const recipeFoods = [
         order: 1,
         repeatable: false,
         category_code: 'SW01',
+        required: true,
       },
       {
         code: 'SND_2',
@@ -20,6 +21,7 @@ const recipeFoods = [
         order: 2,
         repeatable: false,
         category_code: 'SW02',
+        required: false,
       },
       {
         code: 'SND_3',
@@ -29,6 +31,7 @@ const recipeFoods = [
         order: 3,
         repeatable: false,
         category_code: 'SW03',
+        required: false,
       },
       {
         code: 'SND_4',
@@ -37,6 +40,7 @@ const recipeFoods = [
         order: 4,
         repeatable: false,
         category_code: 'SW04',
+        required: false,
       },
       {
         code: 'SND_5',
@@ -45,6 +49,7 @@ const recipeFoods = [
         order: 5,
         repeatable: true,
         category_code: 'SW05',
+        required: false,
       },
       {
         code: 'SND_6',
@@ -53,6 +58,7 @@ const recipeFoods = [
         order: 6,
         repeatable: true,
         category_code: 'SW06',
+        required: false,
       },
     ],
   },
@@ -66,6 +72,7 @@ const recipeFoods = [
         order: 1,
         repeatable: true,
         category_code: 'SLW1',
+        required: true,
       },
       {
         code: 'SLD_2',
@@ -74,6 +81,7 @@ const recipeFoods = [
         order: 2,
         repeatable: true,
         category_code: 'SLW2',
+        required: false,
       },
     ],
   },

--- a/packages/db/src/models/foods/recipe-foods-steps.ts
+++ b/packages/db/src/models/foods/recipe-foods-steps.ts
@@ -26,7 +26,16 @@ import RecipeFoods from './recipe-foods';
 
 @Scopes(() => ({
   list: {
-    attributes: ['id', 'recipeFoodsId', 'code', 'order', 'name', 'description', 'repeatable'],
+    attributes: [
+      'id',
+      'recipeFoodsId',
+      'code',
+      'order',
+      'name',
+      'description',
+      'repeatable',
+      'required',
+    ],
     order: [['order', 'ASC']],
   },
 }))
@@ -126,6 +135,13 @@ export default class RecipeFoodsSteps extends BaseModel<
     defaultValue: false,
   })
   declare repeatable: boolean;
+
+  @Column({
+    allowNull: false,
+    type: DataType.BOOLEAN,
+    defaultValue: false,
+  })
+  declare required: boolean;
 
   @CreatedAt
   declare readonly createdAt: CreationOptional<Date>;

--- a/packages/i18n/src/admin/en/locales.json
+++ b/packages/i18n/src/admin/en/locales.json
@@ -66,7 +66,8 @@
     "description": "Step Description",
     "ingredientsCategory": "Step Ingredients Category",
     "order": "Step Order",
-    "repeat": "Many ingredients"
+    "repeat": "Many ingredients",
+    "require": "Required"
   },
 
   "food-ranking": {

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -381,7 +381,7 @@
     "remove": "Remove",
     "missing": {
       "label": "I can't find my food",
-      "description": "<p>If you can't find your food in the list, try rephrasing your description in the search text box above and click 'search again'.</p><p>Or click 'Browse all foods' and explore the food categories.</p><p>If you still can't find your food, click 'Report a missing food'.</p>",
+      "description": "<p>Please try browsing the food categories listed above to find your food.</p><p>If you still can't find it, please click the button below to report a missing food.</p>",
       "report": "Report a missing food",
       "tryAgain": "OK, let me try again",
       "irrelevantIngredient": "I didn't have any {ingredient}"

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -371,7 +371,7 @@
     "text": "",
     "description": "Please follow the steps below to build your own recipe for {food}.",
     "label": "Add your own {searchTerm}",
-    "browse": "Browse all foods",
+    "browse": "{category} categories",
     "search": "Search for a food",
     "root": "all food categories",
     "back": "Back to '{category}'",

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -379,6 +379,7 @@
     "noMore": "No more ingredients",
     "none": "No food results. Please try refining your search.",
     "remove": "Remove",
+    "missingAllIngredients": "Please add at least one ingredient to continue.",
     "missing": {
       "label": "I can't find my food",
       "description": "<p>Please try browsing the food categories listed above to find your food.</p><p>If you still can't find it, please click the button below to report a missing food.</p>",

--- a/packages/i18n/src/shared/fr/prompts.json
+++ b/packages/i18n/src/shared/fr/prompts.json
@@ -382,6 +382,7 @@
     "back": "Retour à '{category}'",
     "none": "Aucun résultat concernant les aliments. Veuillez affiner votre recherche.",
     "remove": "Retirer",
+    "missingAllIngredients": "Veuillez ajouter au moins un ingrédient pour continuer.",
     "missing": {
       "label": "Je ne trouve pas ma nourriture",
       "description": "<p>Si vous ne trouvez pas votre aliment dans la liste, essayez de reformuler votre description dans le champ de recherche ci-dessus et cliquez sur \"Chercher à nouveau\".</p><p>Vous pouvez également cliquer sur \"Parcourir tous les aliments\" et explorer les catégories d'aliments.</p><p>Si vous ne trouvez toujours pas votre aliment, cliquez sur \"Signaler un aliment manquant\".</p>",

--- a/packages/i18n/src/shared/fr/prompts.json
+++ b/packages/i18n/src/shared/fr/prompts.json
@@ -376,7 +376,7 @@
     "name": "{food} créateur de recettes",
     "text": "",
     "description": "Veuillez suivre les étapes ci-dessous pour créer votre propre recette pour {food}.",
-    "browse": "Parcourir tous les aliments",
+    "browse": "Parcourir tous {category}",
     "search": "Recherche d'un aliment",
     "root": "toutes les catégories d'aliments",
     "back": "Retour à '{category}'",

--- a/packages/i18n/src/shared/ms/prompts.json
+++ b/packages/i18n/src/shared/ms/prompts.json
@@ -372,7 +372,7 @@
     "text": "",
     "description": "Please follow the steps below to build your own recipe for {food}.",
     "label": "Add your own {searchTerm}",
-    "browse": "Browse all foods",
+    "browse": "{category} categories",
     "search": "Search for a food",
     "root": "all food categories",
     "back": "Back to '{category}'",

--- a/packages/i18n/src/shared/ms/prompts.json
+++ b/packages/i18n/src/shared/ms/prompts.json
@@ -382,7 +382,7 @@
     "remove": "Remove",
     "missing": {
       "label": "I can't find my food",
-      "description": "<p>If you can't find your food in the list, try rephrasing your description in the search text box above and click 'search again'.</p><p>Or click 'Browse all foods' and explore the food categories.</p><p>If you still can't find your food, click 'Report a missing food'.</p>",
+      "description": "<p>Please try browsing the food categories listed above to find your food.</p><p>If you still can't find it, please click the button below to report a missing food.</p>",
       "report": "Report a missing food",
       "tryAgain": "OK, let me try again",
       "irrelevantIngredient": "I didn't have any {ingredient}"

--- a/packages/i18n/src/shared/ms/prompts.json
+++ b/packages/i18n/src/shared/ms/prompts.json
@@ -380,6 +380,7 @@
     "noMore": "No more ingredients",
     "none": "No food results. Please try refining your search.",
     "remove": "Remove",
+    "missingAllIngredients": "Sila tambah sekurang-kurangnya satu bahan untuk meneruskan.",
     "missing": {
       "label": "I can't find my food",
       "description": "<p>Please try browsing the food categories listed above to find your food.</p><p>If you still can't find it, please click the button below to report a missing food.</p>",

--- a/packages/i18n/src/shared/ta/prompts.json
+++ b/packages/i18n/src/shared/ta/prompts.json
@@ -380,6 +380,7 @@
     "noMore": "No more ingredients",
     "none": "No food results. Please try refining your search.",
     "remove": "Remove",
+    "missingAllIngredients": "தொடர்வதற்கு குறைந்தபட்சம் ஒரு பொருளை சேர்க்கவும்.",
     "missing": {
       "label": "I can't find my food",
       "description": "<p>Please try browsing the food categories listed above to find your food.</p><p>If you still can't find it, please click the button below to report a missing food.</p>",

--- a/packages/i18n/src/shared/ta/prompts.json
+++ b/packages/i18n/src/shared/ta/prompts.json
@@ -372,7 +372,7 @@
     "text": "",
     "description": "Please follow the steps below to build your own recipe for {food}.",
     "label": "Add your own {searchTerm}",
-    "browse": "Browse all foods",
+    "browse": "{category} categories",
     "search": "Search for a food",
     "root": "all food categories",
     "back": "Back to '{category}'",

--- a/packages/i18n/src/shared/ta/prompts.json
+++ b/packages/i18n/src/shared/ta/prompts.json
@@ -382,7 +382,7 @@
     "remove": "Remove",
     "missing": {
       "label": "I can't find my food",
-      "description": "<p>If you can't find your food in the list, try rephrasing your description in the search text box above and click 'search again'.</p><p>Or click 'Browse all foods' and explore the food categories.</p><p>If you still can't find your food, click 'Report a missing food'.</p>",
+      "description": "<p>Please try browsing the food categories listed above to find your food.</p><p>If you still can't find it, please click the button below to report a missing food.</p>",
       "report": "Report a missing food",
       "tryAgain": "OK, let me try again",
       "irrelevantIngredient": "I didn't have any {ingredient}"

--- a/packages/i18n/src/shared/zh/prompts.json
+++ b/packages/i18n/src/shared/zh/prompts.json
@@ -379,6 +379,7 @@
     "noMore": "No more ingredients",
     "none": "No food results. Please try refining your search.",
     "remove": "Remove",
+    "missingAllIngredients": "请至少添加一个成分以继续。",
     "missing": {
       "label": "I can't find my food",
       "description": "<p>Please try browsing the food categories listed above to find your food.</p><p>If you still can't find it, please click the button below to report a missing food.</p>",

--- a/packages/i18n/src/shared/zh/prompts.json
+++ b/packages/i18n/src/shared/zh/prompts.json
@@ -381,7 +381,7 @@
     "remove": "Remove",
     "missing": {
       "label": "I can't find my food",
-      "description": "<p>If you can't find your food in the list, try rephrasing your description in the search text box above and click 'search again'.</p><p>Or click 'Browse all foods' and explore the food categories.</p><p>If you still can't find your food, click 'Report a missing food'.</p>",
+      "description": "<p>Please try browsing the food categories listed above to find your food.</p><p>If you still can't find it, please click the button below to report a missing food.</p>",
       "report": "Report a missing food",
       "tryAgain": "OK, let me try again",
       "irrelevantIngredient": "I didn't have any {ingredient}"

--- a/packages/i18n/src/shared/zh/prompts.json
+++ b/packages/i18n/src/shared/zh/prompts.json
@@ -371,7 +371,7 @@
     "text": "",
     "description": "Please follow the steps below to build your own recipe for {food}.",
     "label": "Add your own {searchTerm}",
-    "browse": "Browse all foods",
+    "browse": "{category} categories",
     "search": "Search for a food",
     "root": "all food categories",
     "back": "Back to '{category}'",


### PR DESCRIPTION
- [x] Drop the ‘browse all foods’ sentence and instead replace it with '<StepName> categories as per sys v3

- [x] Admin: Add “Required” Option to the Admin Dashboard (locale → recipe foods → steps)

- [x] Survey: Make some steps Required (configurable via locale->recipe foods → steps

- [x] Survey: Change text for the Missing Food Prompt 

- [x] ‘I DIDN'T HAVE ANY X' for all steps won’t be possible to continue, and the system will show the message that at least one ingredient (step) is needed