### PR TITLE
Alternative food names

### DIFF
--- a/apps/api/src/food-index/language-backends/en/english-language-backend.ts
+++ b/apps/api/src/food-index/language-backends/en/english-language-backend.ts
@@ -8,6 +8,7 @@ const sanitiseRegexp = new RegExp(/[.`,/\\\-+)(]|e\.g\.|e\.g|'s/g);
 
 export default {
   name: 'English',
+  languageCode: 'en',
   indexIgnore: ['and', 'the', 'with', 'from'],
   phoneticEncoder: new Metaphone3Encoder(),
 

--- a/apps/api/src/food-index/language-backends/fr/french-language-backend.ts
+++ b/apps/api/src/food-index/language-backends/fr/french-language-backend.ts
@@ -8,6 +8,7 @@ const sanitiseRegexp = new RegExp(/[.`,/\\\-+)(]|e\.g\.|e\.g|n\.s\.'s/g);
 
 export default {
   name: 'French',
+  languageCode: 'fr',
   indexIgnore: ['de', 'au', 'aux', 'pour'],
   phoneticEncoder: new FrenchPhoneticEncoder(),
 

--- a/apps/api/src/food-index/phrase-index.ts
+++ b/apps/api/src/food-index/phrase-index.ts
@@ -31,6 +31,7 @@ export type RecipeFoodTuple = [key: string, entry: RecipeFoodsHeader];
 
 export interface LanguageBackend {
   name: string;
+  languageCode: string;
   indexIgnore: string[];
   phoneticEncoder: PhoneticEncoder | undefined;
 

--- a/apps/api/src/food-index/workers/food-data.ts
+++ b/apps/api/src/food-index/workers/food-data.ts
@@ -1,4 +1,6 @@
+import type { LocaleTranslation } from '@intake24/common/types';
 import type { CategoryHeader } from '@intake24/common/types/http';
+import type { AlternativeFoodNames } from '@intake24/db';
 import { Category, CategoryLocal, FoodLocalList, RecipeFoods, SynonymSet } from '@intake24/db';
 
 import type { RecipeFoodTuple } from '../phrase-index';
@@ -6,6 +8,7 @@ import type { RecipeFoodTuple } from '../phrase-index';
 export type LocalFoodData = {
   code: string;
   name: string;
+  altNames: AlternativeFoodNames;
   parentCategories: Set<string>;
 };
 
@@ -45,7 +48,7 @@ export async function fetchLocalFoods(localeId: string): Promise<LocalFoodData[]
     include: {
       required: true,
       association: 'foodLocal',
-      attributes: ['name'],
+      attributes: ['name', 'altNames'],
       where: { localeId },
       include: [
         {
@@ -68,6 +71,7 @@ export async function fetchLocalFoods(localeId: string): Promise<LocalFoodData[]
     return {
       code: row.foodCode,
       name: row.foodLocal!.name,
+      altNames: row.foodLocal!.altNames,
       parentCategories,
     };
   });

--- a/apps/api/src/food-index/workers/index-builder.ts
+++ b/apps/api/src/food-index/workers/index-builder.ts
@@ -120,6 +120,12 @@ async function buildIndexForLocale(localeId: string): Promise<LocalFoodIndex> {
     if (!food.name) continue;
 
     foodDescriptions.push({ phrase: food.name, key: food.code });
+
+    const altNames = food.altNames[languageBackend.languageCode];
+
+    if (altNames !== undefined) {
+      for (const name of altNames) foodDescriptions.push({ phrase: name, key: food.code });
+    }
   }
 
   const categoryDescriptions = new Array<PhraseWithKey<string>>();

--- a/apps/api/src/http/routers/survey.router.ts
+++ b/apps/api/src/http/routers/survey.router.ts
@@ -59,7 +59,7 @@ export const survey = () => {
     generateUser: {
       middleware: [generateUserLimiter],
       handler: async ({ body: { captcha }, params: { slug }, req }) => {
-        await captchaCheck(captcha, captchaConfig);
+        await captchaCheck(captcha ?? undefined, captchaConfig);
 
         const {
           respondent: { username },

--- a/apps/api/src/services/admin/local-foods.service.ts
+++ b/apps/api/src/services/admin/local-foods.service.ts
@@ -281,6 +281,7 @@ const localFoodsService = ({ db }: Pick<IoC, 'db'>) => {
       if (options.update) {
         instance.name = request.name;
         instance.simpleName = toSimpleName(request.name);
+        instance.altNames = request.altNames ?? {};
         instance.version = randomUUID();
 
         await instance.save({ transaction });
@@ -295,6 +296,7 @@ const localFoodsService = ({ db }: Pick<IoC, 'db'>) => {
           localeId,
           foodCode: request.code,
           name: request.name,
+          altNames: request.altNames,
           version: randomUUID(),
           simpleName: toSimpleName(request.name),
         },

--- a/apps/api/src/services/survey/survey-submission.service.ts
+++ b/apps/api/src/services/survey/survey-submission.service.ts
@@ -187,7 +187,7 @@ const surveySubmissionService = ({
       }
 
       const {
-        data: { code, groupCode, reasonableAmount },
+        data: { code, groupCode, reasonableAmount, localName },
         flags,
         linkedFoods,
         portionSize,
@@ -212,7 +212,6 @@ const surveySubmissionService = ({
 
       const {
         nutrientRecords,
-        name: localName,
         main: { name: englishName },
       } = foodRecord;
       const { id: foodGroupId, name: foodGroupEnglishName, localGroups } = foodGroupRecord;

--- a/apps/cli/src/commands/fr-inca3/types/food-shadows.ts
+++ b/apps/cli/src/commands/fr-inca3/types/food-shadows.ts
@@ -1,0 +1,11 @@
+export interface INCA3FoodShadowsRow {
+  A_CODE: string;
+  SYNONYME1?: string;
+  SYNONYME2?: string;
+  SYNONYME3?: string;
+  SYNONYME4?: string;
+  SYNONYME5?: string;
+  SYNONYME6?: string;
+  SYNONYME7?: string;
+  SYNONYME8?: string;
+}

--- a/apps/cli/src/commands/fr-inca3/types/recipe-shadows.ts
+++ b/apps/cli/src/commands/fr-inca3/types/recipe-shadows.ts
@@ -1,0 +1,11 @@
+export interface INCA3RecipeShadowsRow {
+  R_CODE: string;
+  SYNONYME1?: string;
+  SYNONYME2?: string;
+  SYNONYME3?: string;
+  SYNONYME4?: string;
+  SYNONYME5?: string;
+  SYNONYME6?: string;
+  SYNONYME7?: string;
+  SYNONYME8?: string;
+}

--- a/apps/cli/src/commands/packager/types/foods.ts
+++ b/apps/cli/src/commands/packager/types/foods.ts
@@ -104,6 +104,7 @@ export interface PkgLocalFood {
   code: string;
   version?: string;
   localDescription?: string;
+  alternativeNames?: Record<string, string[]>;
   nutrientTableCodes: Record<string, string>;
   portionSize: PkgPortionSizeMethod[];
   associatedFoods: PkgAssociatedFood[];

--- a/apps/cli/src/commands/packager/types/v3-type-conversions.ts
+++ b/apps/cli/src/commands/packager/types/v3-type-conversions.ts
@@ -293,6 +293,7 @@ function packageLocalFood(code: string, localFood: LocalFoodRecordV3): PkgLocalF
     version: localFood.version ?? undefined,
     localDescription:
       localFood.localDescription.length === 1 ? localFood.localDescription[0] : undefined,
+    alternativeNames: {},
     associatedFoods: localFood.associatedFoods.map(packageAssociatedFood),
     brandNames: localFood.brandNames,
     nutrientTableCodes: localFood.nutrientTableCodes,

--- a/apps/cli/src/commands/packager/types/v4-type-conversions.ts
+++ b/apps/cli/src/commands/packager/types/v4-type-conversions.ts
@@ -150,6 +150,7 @@ function fromPackageLocalFood(localFood: PkgLocalFood): CreateLocalFoodRequest {
   return {
     code: localFood.code,
     name: localFood.localDescription ?? 'Missing local description!',
+    altNames: localFood.alternativeNames,
     associatedFoods: localFood.associatedFoods.map((af) => fromPackageAssociatedFood(af)),
     portionSizeMethods: localFood.portionSize.map((psm) => fromPackagePortionSizeMethod(psm)),
     nutrientTableCodes: localFood.nutrientTableCodes,

--- a/apps/survey/src/components/prompts/standard/FoodSearchPrompt.vue
+++ b/apps/survey/src/components/prompts/standard/FoodSearchPrompt.vue
@@ -72,6 +72,10 @@ export default defineComponent({
 
     const foodSelected = async (food: FoodHeader) => {
       const foodData = await foodsService.getData(props.localeId, food.code);
+      // Food data API returns the main local food name.
+      // Override it here with the selected name (which could be one of the
+      // alternative food names or the main name).
+      foodData.localName = food.name;
       ctx.emit('food-selected', foodData);
     };
 

--- a/packages/common/src/contracts/survey.contract.ts
+++ b/packages/common/src/contracts/survey.contract.ts
@@ -33,7 +33,7 @@ export const survey = initContract().router({
     body: z.object({
       captcha: z
         .string()
-        .optional()
+        .nullish()
         .openapi({ description: 'Captcha token if enabled on system level' }),
     }),
     responses: {

--- a/packages/common/src/types/http/admin/foods.ts
+++ b/packages/common/src/types/http/admin/foods.ts
@@ -35,6 +35,7 @@ export type UpdateGlobalFoodRequest = Omit<CreateGlobalFoodRequest, 'code'>;
 export type CreateLocalFoodRequest = {
   code: string;
   name: string;
+  altNames?: Record<string, string[]>;
   nutrientTableCodes: Record<string, string>;
   portionSizeMethods: PortionSizeMethod[];
   associatedFoods: AssociatedFood[];

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "db:foods:migrate": "pnpm sequelize db:migrate --options-path sequelize/foods/options.js",
+    "db:foods:migration:new": "pnpm sequelize migration:generate --migrations-path sequelize/foods/migrations",
     "db:foods:migrate:undo": "pnpm sequelize db:migrate:undo --options-path sequelize/foods/options.js",
     "db:foods:kysely-codegen": "pnpm exec kysely-codegen --dialect postgres --url \"env(DB_DEV_FOODS_URL)\" --camel-case --out-file ./src/kysely/foods.d.ts",
     "db:system:migrate": "pnpm sequelize db:migrate --options-path sequelize/system/options.js",

--- a/packages/db/sequelize/foods/migrations/20240320104753-food_locals_alt_names.js
+++ b/packages/db/sequelize/foods/migrations/20240320104753-food_locals_alt_names.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('food_locals', 'alt_names', {
+      type: Sequelize.STRING(2048),
+      allowNull: false,
+      defaultValue: '{}',
+      unique: false,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('food_locals', 'alt_names');
+  },
+};

--- a/packages/db/src/models/foods/food-local.ts
+++ b/packages/db/src/models/foods/food-local.ts
@@ -16,6 +16,7 @@ import {
   Table,
 } from 'sequelize-typescript';
 
+import type { LocaleTranslation } from '@intake24/common/types';
 import type {
   FoodNutrientCreationAttributes,
   FoodPortionSizeMethodCreationAttributes,
@@ -31,6 +32,8 @@ import {
 
 import BaseModel from '../model';
 import NutrientTableRecord from './nutrient-table-record';
+
+export type AlternativeFoodNames = Record<string, string[]>;
 
 @Scopes(() => ({
   food: { include: [{ model: Food }] },
@@ -80,6 +83,19 @@ export default class FoodLocal extends BaseModel<
     type: DataType.STRING(256),
   })
   declare simpleName: string | null;
+
+  @Column({
+    allowNull: true,
+    type: DataType.STRING(2048),
+    get() {
+      const val = this.getDataValue('altNames') as unknown;
+      return val ? JSON.parse(val as string) : {};
+    },
+    set(value: AlternativeFoodNames) {
+      this.setDataValue('altNames', JSON.stringify(value ?? {}));
+    },
+  })
+  declare altNames: CreationOptional<AlternativeFoodNames>;
 
   @Column({
     allowNull: false,


### PR DESCRIPTION
Allows foods to have alternative descriptions that are treated as separate index entries but refer to the same food code. The selected name variant is carried over into the output data.

Only one language per locale is supported by the food index at the moment (determined by the selected language backend) but the new column for alternative names (alt_names in food_locals) allows for alternative descriptions in multiple languages.

The admin UI is not implemented yet and it is only possible to add alternative names using the API or the package CLI tool.
