### PR TITLE
Clean up recipe builder respondent UI

### DIFF
--- a/apps/survey/src/components/elements/SelectedFoodList.vue
+++ b/apps/survey/src/components/elements/SelectedFoodList.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card v-if="show" class="pa-0" flat>
+  <v-card v-if="show" flat>
     <v-card-text class="d-flex flex-column flex-md-row pa-0 ga-2">
       <v-container>
         <v-row
@@ -8,7 +8,7 @@
           align="baseline"
           class="pa-0"
         >
-          <v-alert class="flex-md-grow-1 mr-1" color="grey lighten-4" dense icon="$food">
+          <v-alert class="flex-md-grow-1 pa-0 ml-1" color="grey lighten-4" dense icon="$food">
             {{ step.foods[foodIndex].name }}
             <template #prepend>
               <v-icon left>

--- a/apps/survey/src/components/handlers/portion-size/RecipeBuilderPromptHandler.vue
+++ b/apps/survey/src/components/handlers/portion-size/RecipeBuilderPromptHandler.vue
@@ -40,6 +40,7 @@ import { useFoodPromptUtils, useMealPromptUtils, usePromptHandlerStore } from '.
 function initialPromptState(step: RecipeFoodStepsType): RecipeBuilderStepState {
   return {
     confirmed: undefined,
+    anotherFoodConfirmed: undefined,
     repeat: step.repeatable,
     foods: [],
     order: step.order - 1,

--- a/packages/common/src/prompts/prompt-states.ts
+++ b/packages/common/src/prompts/prompt-states.ts
@@ -41,6 +41,7 @@ export type FoodRecipeBuilderItemState =
 
 export type RecipeBuilderStepState = {
   confirmed?: 'yes' | 'no';
+  anotherFoodConfirmed?: boolean;
   foods: FoodRecipeBuilderItemState[];
   order: number;
   description: RequiredLocaleTranslation;

--- a/packages/i18n/src/shared/en/prompts.json
+++ b/packages/i18n/src/shared/en/prompts.json
@@ -388,8 +388,13 @@
     "search": "Search for a food",
     "root": "all food categories",
     "back": "Back to '{category}'",
-    "addMore": "Add more ingredients",
-    "noMore": "No more ingredients",
+    "optional": {
+      "confirm": "Yes",
+      "reject": "No",
+      "infoPrompt": "What was it?"
+    },
+    "addMore": "Add another",
+    "noMore": "Done",
     "none": "No food results. Please try refining your search.",
     "remove": "Remove",
     "missingAllIngredients": "Please add at least one ingredient to continue.",

--- a/packages/i18n/src/shared/fr/prompts.json
+++ b/packages/i18n/src/shared/fr/prompts.json
@@ -381,6 +381,13 @@
     "search": "Chercher un aliment",
     "root": "toutes les catégories alimentaires",
     "back": "Retour vers '{category}'",
+    "optional": {
+      "confirm": "Oui",
+      "reject": "Non",
+      "infoPrompt": "Qu'est-ce que c'était?"
+    },
+    "addMore": "Ajouter un autre",
+    "noMore": "Complet",
     "none": "Pas d'aliments correspondants. Essayez de préciser votre recherche.",
     "remove": "Enlever",
     "missing": {
@@ -388,9 +395,7 @@
       "description": "<p>Si vous ne trouvez pas votre aliment dans la liste, essayez de reformuler votre description dans la barre de recherche ci-dessus et cliquez sur 'Chercher à nouveau'.</p><p>Ou cliquez 'Parcourir tous les aliments' et explorez les catégories alimentaires.</p><p>Si vous n'arrivez toujours pas à trouver votre aliment, cliquez sur 'Signaler un aliment manquant'.</p>",
       "report": "Signaler un aliment manquant",
       "tryAgain": "Ok, laissez-moi réessayer"
-    },
-    "addMore": "Ajouter plus d'ingrédients",
-    "noMore": "Plus d'autres ingrédients"
+    }
   },
   "parentFoodPortion": {
     "name": "Portion alimentaire parent",


### PR DESCRIPTION
Addresses several recipe builder issues (V4-1142, V4-1143, V4-1144):

- Make optional steps explicit and freely toggleable between confirm/reject states
- Change 'Add more ingredients'/'No more ingredients' radio options to more intuitive toggle buttons
- Clean up completion detection