### PR TITLE
Clean up circular imports

### DIFF
--- a/apps/api/circular-dependency-utils.js
+++ b/apps/api/circular-dependency-utils.js
@@ -1,0 +1,123 @@
+/* eslint-disable regexp/no-trivially-nested-quantifier */
+/* eslint-disable regexp/no-super-linear-backtracking */
+/* eslint-disable style/no-multi-spaces */
+
+import fs  from 'node:fs';
+import path from 'node:path';
+
+const sequelizeDecorators = [
+  'HasMany',
+  'BelongsTo',
+  'HasOne',
+  'BelongsToMany',
+  'Scope',
+  'ForeignKey',
+];
+
+export function onlySequelizeDecoratorImports(fromPath, toPath) {
+  // console.log(`Checking ${fromPath} -> ${toPath}`);
+  const source = fs.readFileSync(fromPath, 'utf-8');
+
+  const usedInDecorators = new Set();
+
+  const contentPattern = '(?:[^()]+|\\([^()]*\\))*';
+
+  const decoratorsRegex = new RegExp(
+    `@(${sequelizeDecorators.join('|')})\\s*\\((${contentPattern})\\)`,
+    'g',
+  );
+
+  let match = decoratorsRegex.exec(source);
+
+  while (match !== null) {
+    const content = match[2];
+
+    const modelRegex = /\(\s*\)\s*=>\s*(\w+)/g;
+
+    let modelMatch = modelRegex.exec(content);
+
+    while (modelMatch !== null) {
+      usedInDecorators.add(modelMatch[1]);
+      modelMatch = modelRegex.exec(content);
+    }
+
+    match = decoratorsRegex.exec(source);
+  }
+
+  //   if (usedInDecorators.size > 0) {
+  //     console.warn(`Models used in Sequelize decorators: ${Array.from(usedInDecorators).join(', ')}`);
+  //   }
+  //   else {
+  //     console.warn(`No Sequelize decorators found.`);
+  //   }
+
+  if (usedInDecorators.size === 0) {
+    return false;
+  }
+
+  // Relative import path without extension
+  let relativePath = path.relative(path.dirname(fromPath), toPath);
+  relativePath = relativePath.replace(path.extname(relativePath), '');
+  relativePath = relativePath.replace(/\\/g, '/');
+
+  // Escape the relative path for use in regex (to handle special chars like . or /)
+  const escapedRelativePath = relativePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  const importRegex = new RegExp(
+    `import\\s+`                                   // 'import' followed by mandatory space (JS syntax requires it)
+    + `(\\*\\s+as\\s+(\\w+)`                       // Group 1 & 2: * as namespace with mandatory spaces
+    + `|`
+    + `{\\s*([\\w\\s,]+)\\s*}`                     // Group 3: { named imports } with optional internal spaces
+    + `|`
+    + `(\\w+)`                                     // Group 4: default import
+    + `)`
+    + `\\s+from\\s+`                               // mandatory spaces around 'from' (JS syntax)
+    + `['"]([./]*)?${escapedRelativePath}['"]`,    // quoted path with optional ./ or ../
+    'g',
+  );
+
+  const importedNames = new Set();
+
+  match = importRegex.exec(source);
+  while (match !== null) {
+    if (match[2]) { // Import all (* as ns)
+      return false;
+    }
+    else if (match[3]) { // Named imports { a, b }
+      const names = match[3]
+        .split(',')
+        .map(n => n.trim())
+        .filter(Boolean);
+
+      names.forEach(name => importedNames.add(name));
+    }
+    else if (match[4]) { // Default import
+      importedNames.add(match[4]);
+    }
+    match = importRegex.exec(source);
+  }
+
+  const isSafe = Array.from(importedNames).every(name => usedInDecorators.has(name));
+
+  //   if (isSafe) {
+  //     console.log(`Safe import from ${relativePath}: ${Array.from(importedNames).join(', ')} matches decorators`);
+  //   }
+  //   else {
+  //     console.warn(`Unsafe import from ${relativePath}: ${Array.from(importedNames).join(', ')} does not fully match decorators`);
+  //   }
+
+  return isSafe;
+}
+
+export function isSubpath(basePath, targetPath) {
+  const absBase = path.resolve(basePath);
+  const absTarget = path.resolve(targetPath);
+
+  const relative = path.relative(absBase, absTarget);
+
+  if (relative === '') {
+    return false;
+  }
+
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -119,6 +119,7 @@
     "@types/validator": "^13.15.7",
     "@types/web-push": "^3.6.4",
     "@types/webpack-env": "^1.18.8",
+    "circular-dependency-plugin": "^5.2.2",
     "cross-env": "^10.1.0",
     "fork-ts-checker-webpack-plugin": "^9.1.0",
     "nodemon": "^3.1.11",

--- a/apps/api/src/http/responses/admin/respondents.ts
+++ b/apps/api/src/http/responses/admin/respondents.ts
@@ -1,5 +1,5 @@
 import type { SiteUrls } from '@intake24/api/config';
-import { surveyUrlService } from '@intake24/api/services';
+import surveyUrlService from '@intake24/api/services/survey/survey-url.service';
 import type {
   RespondentEntry,
   RespondentListEntry,

--- a/apps/api/src/ioc/index.ts
+++ b/apps/api/src/ioc/index.ts
@@ -11,6 +11,8 @@ export * from './ioc';
 function configureContainer() {
   const container = createContainer<RequestIoC>({ strict: true });
 
+  const resolveDynamic = <T>(name: string): T => container.resolve<T>(name);
+
   container.register({
     config: asValue(config),
     aclConfig: asValue(config.acl),
@@ -35,6 +37,7 @@ function configureContainer() {
     db: asClass(Database).singleton(),
     kyselyDb: asClass(KyselyDatabases).singleton(),
     models: asValue(models),
+    resolveDynamic: asValue(resolveDynamic),
   });
 
   controllers(container);

--- a/apps/api/src/ioc/ioc.ts
+++ b/apps/api/src/ioc/ioc.ts
@@ -197,6 +197,9 @@ export interface IoC extends Jobs {
   surveySubmissionService: SurveySubmissionService;
   popularityCountersService: PopularityCountersService;
   userService: UserService;
+
+  // Dynamic dependency resolver
+  resolveDynamic: <T>(name: string) => T;
 }
 
 export interface RequestIoC extends IoC {

--- a/apps/api/webpack.config.js
+++ b/apps/api/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('node:path');
+const CircularDependencyPlugin = require('circular-dependency-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const NodemonPlugin = require('nodemon-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
@@ -22,6 +23,16 @@ module.exports = (env) => {
         script: './dist/server.js',
         watch: ['./dist', '.env'],
         nodeArgs: ['--trace-warnings', inspectBreak ? '--inspect-brk=9229' : '--inspect=5959'],
+      }),
+    );
+
+    plugins.push(
+      new CircularDependencyPlugin({
+        exclude: /node_modules/,
+        failOnError: false,
+        onDetected({ paths, compilation }) {
+          compilation.warnings.push(new Error(`${paths[0]}: circular import: ${paths.join(' -> ')}`));
+        },
       }),
     );
   }

--- a/packages/db/sequelize/system/migrations/20253009144130-surveys-schemes-data-export.js
+++ b/packages/db/sequelize/system/migrations/20253009144130-surveys-schemes-data-export.js
@@ -1,0 +1,96 @@
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: queryInterface =>
+    queryInterface.sequelize.transaction(async (transaction) => {
+      const { QueryTypes } = queryInterface.sequelize;
+
+      const schemes = await queryInterface.sequelize.query(`SELECT id, data_export FROM survey_schemes;`, {
+        type: QueryTypes.SELECT,
+        transaction,
+      });
+
+      for (const scheme of schemes) {
+        const { id } = scheme;
+        const dataExport = JSON.parse(scheme.data_export);
+
+        if (!dataExport)
+          continue;
+
+        for (const section of dataExport) {
+          switch (section.id) {
+            case 'user': {
+              section.fields = section.fields.map((field) => {
+                if (field.id === 'userId')
+                  return { id: 'id', label: field.label };
+
+                return field;
+              });
+              break;
+            }
+            case 'survey': {
+              section.fields = section.fields.map((field) => {
+                if (field.id === 'surveyId')
+                  return { id: 'id', label: field.label };
+
+                return field;
+              });
+              break;
+            }
+            case 'submission': {
+              section.fields = section.fields.map((field) => {
+                if (field.id === 'submissionId')
+                  return { id: 'id', label: field.label };
+
+                return field;
+              });
+              break;
+            }
+            case 'meal': {
+              section.fields = section.fields.map((field) => {
+                if (field.id === 'mealId')
+                  return { id: 'id', label: field.label };
+                if (field.id === 'mealIndex')
+                  return { id: 'index', label: field.label };
+
+                return field;
+              });
+              break;
+            }
+            case 'food': {
+              section.fields = section.fields.map((field) => {
+                if (field.id === 'foodId')
+                  return { id: 'id', label: field.label };
+                if (field.id === 'foodIndex')
+                  return { id: 'index', label: field.label };
+
+                return field;
+              });
+              break;
+            }
+            case 'portionSizes': {
+              section.fields = section.fields.map((field) => {
+                if (field.id === 'portionMethod')
+                  return { id: 'method', label: field.label };
+
+                return field;
+              });
+              break;
+            }
+          }
+        }
+
+        await queryInterface.sequelize.query(
+          `UPDATE survey_schemes SET data_export = :dataExport WHERE id = :id;`,
+          {
+            type: queryInterface.sequelize.QueryTypes.UPDATE,
+            replacements: { id, dataExport: JSON.stringify(dataExport) },
+            transaction,
+          },
+        );
+      }
+    }),
+
+  down: () => {
+    throw new Error('This migration cannot be undone');
+  },
+};

--- a/packages/db/src/models/foods/as-served-image.ts
+++ b/packages/db/src/models/foods/as-served-image.ts
@@ -9,8 +9,10 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 import type { LocaleTranslation } from '@intake24/common/types';
-import { AsServedSet, ProcessedImage } from '.';
+
 import BaseModel from '../model';
+import AsServedSet from './as-served-set';
+import ProcessedImage from './processed-image';
 
 @Scopes(() => ({
   asServedSet: { include: [{ model: AsServedSet }] },

--- a/packages/db/src/models/foods/as-served-set.ts
+++ b/packages/db/src/models/foods/as-served-set.ts
@@ -10,8 +10,10 @@ import type {
 import { BelongsTo, Column, DataType, HasMany, Scopes, Table } from 'sequelize-typescript';
 
 import type { LocaleTranslation } from '@intake24/common/types';
-import { AsServedImage, ProcessedImage } from '.';
+
 import BaseModel from '../model';
+import AsServedImage from './as-served-image';
+import ProcessedImage from './processed-image';
 
 @Scopes(() => ({
   selectionImage: { include: [{ model: ProcessedImage }] },

--- a/packages/db/src/models/foods/associated-foods.ts
+++ b/packages/db/src/models/foods/associated-foods.ts
@@ -9,9 +9,10 @@ import type {
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
 import type { LocaleTranslation } from '@intake24/common/types';
-import { Category, Food } from '@intake24/db';
 
 import BaseModel from '../model';
+import Category from './category';
+import Food from './food';
 
 @Table({
   modelName: 'AssociatedFood',

--- a/packages/db/src/models/foods/brand.ts
+++ b/packages/db/src/models/foods/brand.ts
@@ -8,9 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
-import { Food } from '@intake24/db';
-
 import BaseModel from '../model';
+import Food from './food';
 
 @Table({
   modelName: 'Brand',

--- a/packages/db/src/models/foods/category-attributes.ts
+++ b/packages/db/src/models/foods/category-attributes.ts
@@ -8,8 +8,9 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 import type { UseInRecipeType } from '@intake24/common/types';
-import { Category } from '.';
+
 import BaseModel from '../model';
+import Category from './category';
 
 @Scopes(() => ({
   category: { include: [{ model: Category }] },

--- a/packages/db/src/models/foods/category-category.ts
+++ b/packages/db/src/models/foods/category-category.ts
@@ -6,8 +6,8 @@ import type {
   NonAttribute,
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
-import { Category } from '@intake24/db';
 import BaseModel from '../model';
+import Category from './category';
 
 @Table({
   modelName: 'CategoryCategory',

--- a/packages/db/src/models/foods/category.ts
+++ b/packages/db/src/models/foods/category.ts
@@ -15,16 +15,15 @@ import {
   HasOne,
   Table,
 } from 'sequelize-typescript';
-import {
-  AssociatedFood,
-  CategoryAttribute,
-  CategoryCategory,
-  CategoryPortionSizeMethod,
-  Food,
-  FoodCategory,
-  FoodsLocale,
-} from '.';
+
 import BaseModel from '../model';
+import AssociatedFood from './associated-foods';
+import CategoryAttribute from './category-attributes';
+import CategoryCategory from './category-category';
+import CategoryPortionSizeMethod from './category-portion-size-method';
+import Food from './food';
+import FoodCategory from './food-category';
+import FoodsLocale from './locale';
 
 @Table({
   modelName: 'Category',

--- a/packages/db/src/models/foods/drinkware-scale-v2.ts
+++ b/packages/db/src/models/foods/drinkware-scale-v2.ts
@@ -11,8 +11,9 @@ import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript
 import type { LocaleTranslation } from '@intake24/common/types';
 import type { DrinkwareScaleVolumeMethod } from '@intake24/common/types/http/admin';
 
-import { DrinkwareSet, ProcessedImage } from '.';
 import BaseModel from '../model';
+import DrinkwareSet from './drinkware-set';
+import ProcessedImage from './processed-image';
 
 @Scopes(() => ({
   drinkwareSet: { include: [{ model: DrinkwareSet }] },

--- a/packages/db/src/models/foods/drinkware-scale.ts
+++ b/packages/db/src/models/foods/drinkware-scale.ts
@@ -10,8 +10,9 @@ import { BelongsTo, Column, DataType, HasMany, Scopes, Table } from 'sequelize-t
 
 import type { LocaleTranslation } from '@intake24/common/types';
 
-import { DrinkwareSet, DrinkwareVolumeSample } from '.';
 import BaseModel from '../model';
+import DrinkwareSet from './drinkware-set';
+import DrinkwareVolumeSample from './drinkware-volume-sample';
 
 @Scopes(() => ({
   drinkwareSet: { include: [{ model: DrinkwareSet }] },

--- a/packages/db/src/models/foods/drinkware-set.ts
+++ b/packages/db/src/models/foods/drinkware-set.ts
@@ -9,8 +9,10 @@ import type {
 import { BelongsTo, Column, DataType, HasMany, Scopes, Table } from 'sequelize-typescript';
 
 import type { LocaleTranslation } from '@intake24/common/types';
-import { DrinkwareScale, DrinkwareScaleV2, ImageMap } from '.';
 import BaseModel from '../model';
+import DrinkwareScale from './drinkware-scale';
+import DrinkwareScaleV2 from './drinkware-scale-v2';
+import ImageMap from './image-map';
 
 @Scopes(() => ({
   scales: { include: [{ model: DrinkwareScale }] },

--- a/packages/db/src/models/foods/drinkware-volume-sample.ts
+++ b/packages/db/src/models/foods/drinkware-volume-sample.ts
@@ -8,8 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 
-import { DrinkwareScale } from '.';
 import BaseModel from '../model';
+import DrinkwareScale from './drinkware-scale';
 
 @Scopes(() => ({
   scale: { include: [{ model: DrinkwareScale }] },

--- a/packages/db/src/models/foods/food-category.ts
+++ b/packages/db/src/models/foods/food-category.ts
@@ -7,9 +7,9 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
-import { Category, Food } from '@intake24/db';
-
 import BaseModel from '../model';
+import Category from './category';
+import Food from './food';
 
 @Table({
   timestamps: false,

--- a/packages/db/src/models/foods/food-nutrient.ts
+++ b/packages/db/src/models/foods/food-nutrient.ts
@@ -13,8 +13,9 @@ import {
   Table,
 } from 'sequelize-typescript';
 
-import { Food, NutrientTableRecord } from '.';
 import BaseModel from '../model';
+import Food from './food';
+import NutrientTableRecord from './nutrient-table-record';
 
 @Table({
   modelName: 'FoodNutrient',

--- a/packages/db/src/models/foods/food-portion-size-method.ts
+++ b/packages/db/src/models/foods/food-portion-size-method.ts
@@ -9,8 +9,9 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 import type { PortionSizeMethodId, PortionSizeParameter } from '@intake24/common/surveys';
-import { Food } from '@intake24/db';
+
 import BaseModel from '../model';
+import Food from './food';
 
 @Table({
   modelName: 'FoodPortionSizeMethod',

--- a/packages/db/src/models/foods/food-thumbnail-image.ts
+++ b/packages/db/src/models/foods/food-thumbnail-image.ts
@@ -8,8 +8,10 @@ import type {
   NonAttribute,
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
-import { Food, ProcessedImage } from '.';
+
 import BaseModel from '../model';
+import Food from './food';
+import ProcessedImage from './processed-image';
 
 @Scopes(() => ({
   image: { include: [{ model: ProcessedImage, as: 'image' }] },

--- a/packages/db/src/models/foods/food.ts
+++ b/packages/db/src/models/foods/food.ts
@@ -6,10 +6,8 @@ import type {
   InferCreationAttributes,
   NonAttribute,
 } from 'sequelize';
-import type {
-  FoodNutrientCreationAttributes,
-  FoodPortionSizeMethodCreationAttributes,
-} from '.';
+import type { FoodNutrientCreationAttributes } from './food-nutrient';
+import type { FoodPortionSizeMethodCreationAttributes } from './food-portion-size-method';
 import {
   BelongsTo,
   BelongsToMany,
@@ -19,19 +17,17 @@ import {
   HasOne,
   Table,
 } from 'sequelize-typescript';
-import {
-  AssociatedFood,
-  Brand,
-  Category,
-  FoodAttribute,
-  FoodCategory,
-  FoodNutrient,
-  FoodPortionSizeMethod,
-  FoodThumbnailImage,
-  NutrientTableRecord,
-} from '.';
 import BaseModel from '../model';
+import AssociatedFood from './associated-foods';
+import Brand from './brand';
+import Category from './category';
+import FoodAttribute from './food-attribute';
+import FoodCategory from './food-category';
+import FoodNutrient from './food-nutrient';
+import FoodPortionSizeMethod from './food-portion-size-method';
+import FoodThumbnailImage from './food-thumbnail-image';
 import FoodsLocale from './locale';
+import NutrientTableRecord from './nutrient-table-record';
 
 export type AlternativeFoodNames = Record<string, string[]>;
 

--- a/packages/db/src/models/foods/guide-image-object.ts
+++ b/packages/db/src/models/foods/guide-image-object.ts
@@ -10,8 +10,8 @@ import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
 import type { LocaleTranslation } from '@intake24/common/types';
 
-import { GuideImage } from '.';
 import BaseModel from '../model';
+import GuideImage from './guide-image';
 
 @Table({
   modelName: 'GuideImageObject',

--- a/packages/db/src/models/foods/guide-image.ts
+++ b/packages/db/src/models/foods/guide-image.ts
@@ -9,8 +9,11 @@ import type {
 import { BelongsTo, Column, DataType, HasMany, Scopes, Table } from 'sequelize-typescript';
 
 import type { LocaleTranslation } from '@intake24/common/types';
-import { GuideImageObject, ImageMap, ProcessedImage } from '.';
+
 import BaseModel from '../model';
+import GuideImageObject from './guide-image-object';
+import ImageMap from './image-map';
+import ProcessedImage from './processed-image';
 
 @Scopes(() => ({
   imageMap: { include: [{ model: ImageMap }] },

--- a/packages/db/src/models/foods/image-map-object.ts
+++ b/packages/db/src/models/foods/image-map-object.ts
@@ -10,8 +10,9 @@ import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
 import type { LocaleTranslation } from '@intake24/common/types';
 
-import { ImageMap, ProcessedImage } from '.';
 import BaseModel from '../model';
+import ImageMap from './image-map';
+import ProcessedImage from './processed-image';
 
 @Table({
   modelName: 'ImageMapObject',

--- a/packages/db/src/models/foods/image-map.ts
+++ b/packages/db/src/models/foods/image-map.ts
@@ -9,8 +9,11 @@ import type {
 import { BelongsTo, Column, DataType, HasMany, Scopes, Table } from 'sequelize-typescript';
 
 import type { LocaleTranslation } from '@intake24/common/types';
-import { DrinkwareSet, GuideImage, ImageMapObject, ProcessedImage } from '.';
 import BaseModel from '../model';
+import DrinkwareSet from './drinkware-set';
+import GuideImage from './guide-image';
+import ImageMapObject from './image-map-object';
+import ProcessedImage from './processed-image';
 
 @Scopes(() => ({
   guideImages: { include: [{ model: GuideImage }] },

--- a/packages/db/src/models/foods/locale.ts
+++ b/packages/db/src/models/foods/locale.ts
@@ -8,8 +8,12 @@ import type {
 } from 'sequelize';
 import { Column, DataType, HasMany, Table } from 'sequelize-typescript';
 import type { TextDirection } from '@intake24/common/types';
-import { Category, Food, SplitList, SplitWord, SynonymSet } from '.';
 import BaseModel from '../model';
+import Category from './category';
+import Food from './food';
+import SplitList from './split-list';
+import SplitWord from './split-word';
+import SynonymSet from './synonym-set';
 
 @Table({
   modelName: 'Locale',

--- a/packages/db/src/models/foods/nutrient-table-csv-mapping-field.ts
+++ b/packages/db/src/models/foods/nutrient-table-csv-mapping-field.ts
@@ -8,8 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
-import { NutrientTable } from '.';
 import BaseModel from '../model';
+import NutrientTable from './nutrient-table';
 
 @Table({
   modelName: 'NutrientTableCsvMappingField',

--- a/packages/db/src/models/foods/nutrient-table-csv-mapping-nutrient.ts
+++ b/packages/db/src/models/foods/nutrient-table-csv-mapping-nutrient.ts
@@ -8,8 +8,9 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
-import { FoodsNutrientType, NutrientTable } from '.';
 import BaseModel from '../model';
+import NutrientTable from './nutrient-table';
+import FoodsNutrientType from './nutrient-type';
 
 @Table({
   modelName: 'NutrientTableCsvMappingNutrient',

--- a/packages/db/src/models/foods/nutrient-table-csv-mapping.ts
+++ b/packages/db/src/models/foods/nutrient-table-csv-mapping.ts
@@ -8,8 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
-import { NutrientTable } from '.';
 import BaseModel from '../model';
+import NutrientTable from './nutrient-table';
 
 @Table({
   modelName: 'NutrientTableCsvMapping',

--- a/packages/db/src/models/foods/nutrient-table-record-field.ts
+++ b/packages/db/src/models/foods/nutrient-table-record-field.ts
@@ -8,9 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
-import { NutrientTableRecord } from '@intake24/db';
-
 import BaseModel from '../model';
+import NutrientTableRecord from './nutrient-table-record';
 
 @Table({
   modelName: 'NutrientTableRecordField',

--- a/packages/db/src/models/foods/nutrient-table-record-nutrient.ts
+++ b/packages/db/src/models/foods/nutrient-table-record-nutrient.ts
@@ -9,9 +9,9 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
-import { FoodsNutrientType, NutrientTableRecord } from '@intake24/db';
-
 import BaseModel from '../model';
+import NutrientTableRecord from './nutrient-table-record';
+import FoodsNutrientType from './nutrient-type';
 
 @Table({
   modelName: 'NutrientTableRecordNutrient',

--- a/packages/db/src/models/foods/nutrient-table-record.ts
+++ b/packages/db/src/models/foods/nutrient-table-record.ts
@@ -7,18 +7,15 @@ import type {
   InferCreationAttributes,
   NonAttribute,
 } from 'sequelize';
+import type { NutrientTableRecordNutrientCreationAttributes } from './nutrient-table-record-nutrient';
 import { BelongsTo, BelongsToMany, Column, DataType, HasMany, Table } from 'sequelize-typescript';
 
-import type { NutrientTableRecordNutrientCreationAttributes } from '@intake24/db';
-import {
-  Food,
-  FoodNutrient,
-  NutrientTable,
-  NutrientTableRecordField,
-  NutrientTableRecordNutrient,
-} from '@intake24/db';
-
 import BaseModel from '../model';
+import Food from './food';
+import FoodNutrient from './food-nutrient';
+import NutrientTable from './nutrient-table';
+import NutrientTableRecordField from './nutrient-table-record-field';
+import NutrientTableRecordNutrient from './nutrient-table-record-nutrient';
 
 @Table({
   modelName: 'NutrientTableRecord',

--- a/packages/db/src/models/foods/nutrient-table.ts
+++ b/packages/db/src/models/foods/nutrient-table.ts
@@ -9,13 +9,11 @@ import type {
 import type { NutrientTableRecordCreationAttributes } from './nutrient-table-record';
 
 import { Column, DataType, HasMany, HasOne, Scopes, Table } from 'sequelize-typescript';
-import {
-  NutrientTableCsvMapping,
-  NutrientTableCsvMappingField,
-  NutrientTableCsvMappingNutrient,
-  NutrientTableRecord,
-} from '.';
 import BaseModel from '../model';
+import NutrientTableCsvMapping from './nutrient-table-csv-mapping';
+import NutrientTableCsvMappingField from './nutrient-table-csv-mapping-field';
+import NutrientTableCsvMappingNutrient from './nutrient-table-csv-mapping-nutrient';
+import NutrientTableRecord from './nutrient-table-record';
 
 @Scopes(() => ({
   list: { order: [['id', 'ASC']] },

--- a/packages/db/src/models/foods/nutrient-type-in-kcal.ts
+++ b/packages/db/src/models/foods/nutrient-type-in-kcal.ts
@@ -8,8 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
-import { FoodsNutrientType } from '.';
 import BaseModel from '../model';
+import FoodsNutrientType from './nutrient-type';
 
 @Table({
   modelName: 'NutrientTypeInKcal',

--- a/packages/db/src/models/foods/nutrient-type.ts
+++ b/packages/db/src/models/foods/nutrient-type.ts
@@ -7,8 +7,11 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, HasOne, Scopes, Table } from 'sequelize-typescript';
 
-import { FoodsNutrientUnit, NutrientTableRecordNutrient, NutrientTypeInKcal } from '.';
 import BaseModel from '../model';
+
+import NutrientTableRecordNutrient from './nutrient-table-record-nutrient';
+import NutrientTypeInKcal from './nutrient-type-in-kcal';
+import FoodsNutrientUnit from './nutrient-unit';
 
 @Scopes(() => ({
   unit: { include: [{ model: FoodsNutrientUnit }] },

--- a/packages/db/src/models/foods/nutrient-unit.ts
+++ b/packages/db/src/models/foods/nutrient-unit.ts
@@ -7,8 +7,8 @@ import type {
 } from 'sequelize';
 import { Column, DataType, HasMany, Scopes, Table } from 'sequelize-typescript';
 
-import { FoodsNutrientType } from '.';
 import BaseModel from '../model';
+import FoodsNutrientType from './nutrient-type';
 
 @Scopes(() => ({
   nutrientTypes: { include: [{ model: FoodsNutrientType }] },

--- a/packages/db/src/models/foods/processed-image.ts
+++ b/packages/db/src/models/foods/processed-image.ts
@@ -8,8 +8,12 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, HasMany, Scopes, Table } from 'sequelize-typescript';
 
-import { AsServedImage, AsServedSet, FoodThumbnailImage, ImageMap, SourceImage } from '.';
 import BaseModel from '../model';
+import AsServedImage from './as-served-image';
+import AsServedSet from './as-served-set';
+import FoodThumbnailImage from './food-thumbnail-image';
+import ImageMap from './image-map';
+import SourceImage from './source-image';
 
 export enum ProcessedImagePurposes {
   AsServedMainImage = 1,

--- a/packages/db/src/models/foods/recipe-food-step.ts
+++ b/packages/db/src/models/foods/recipe-food-step.ts
@@ -17,8 +17,9 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 import type { RequiredLocaleTranslation } from '@intake24/common/types';
-import { FoodsLocale } from '@intake24/db';
+
 import BaseModel from '../model';
+import FoodsLocale from './locale';
 import RecipeFood from './recipe-food';
 
 @Scopes(() => ({

--- a/packages/db/src/models/foods/recipe-food.ts
+++ b/packages/db/src/models/foods/recipe-food.ts
@@ -17,10 +17,10 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
-import { FoodsLocale, SynonymSet } from '@intake24/db';
-
 import BaseModel from '../model';
+import FoodsLocale from './locale';
 import RecipeFoodStep from './recipe-food-step';
+import SynonymSet from './synonym-set';
 
 @Scopes(() => ({
   list: {

--- a/packages/db/src/models/foods/source-image-keyword.ts
+++ b/packages/db/src/models/foods/source-image-keyword.ts
@@ -7,8 +7,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 
-import { SourceImage } from '.';
 import BaseModel from '../model';
+import SourceImage from './source-image';
 
 @Scopes(() => ({
   sourceImage: { include: [{ model: SourceImage }] },

--- a/packages/db/src/models/foods/source-image.ts
+++ b/packages/db/src/models/foods/source-image.ts
@@ -8,8 +8,9 @@ import type {
 } from 'sequelize';
 import { Column, DataType, HasMany, Scopes, Table } from 'sequelize-typescript';
 
-import { ProcessedImage, SourceImageKeyword } from '.';
 import BaseModel from '../model';
+import ProcessedImage from './processed-image';
+import SourceImageKeyword from './source-image-keyword';
 
 @Scopes(() => ({
   keywords: { include: [{ model: SourceImageKeyword }] },

--- a/packages/db/src/models/foods/split-list.ts
+++ b/packages/db/src/models/foods/split-list.ts
@@ -8,8 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
-import { FoodsLocale } from '.';
 import BaseModel from '../model';
+import FoodsLocale from './locale';
 
 @Table({
   modelName: 'SplitList',

--- a/packages/db/src/models/foods/split-word.ts
+++ b/packages/db/src/models/foods/split-word.ts
@@ -8,8 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
-import { FoodsLocale } from '.';
 import BaseModel from '../model';
+import FoodsLocale from './locale';
 
 @Table({
   modelName: 'SplitWord',

--- a/packages/db/src/models/foods/synonym-set.ts
+++ b/packages/db/src/models/foods/synonym-set.ts
@@ -8,8 +8,9 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, HasMany, Table } from 'sequelize-typescript';
 
-import { FoodsLocale, RecipeFood } from '.';
 import BaseModel from '../model';
+import FoodsLocale from './locale';
+import RecipeFood from './recipe-food';
 
 @Table({
   modelName: 'SynonymSet',

--- a/packages/db/src/models/system/client-error-report.ts
+++ b/packages/db/src/models/system/client-error-report.ts
@@ -19,8 +19,9 @@ import {
 
 import type { Dictionary } from '@intake24/common/types';
 
-import { Survey, User } from '.';
 import BaseModel from '../model';
+import Survey from './survey';
+import User from './user';
 
 @Scopes(() => ({
   survey: { include: [{ model: Survey }] },

--- a/packages/db/src/models/system/faq.ts
+++ b/packages/db/src/models/system/faq.ts
@@ -19,8 +19,12 @@ import {
 } from 'sequelize-typescript';
 import type { RecordVisibility } from '@intake24/common/security';
 import type { FAQSection } from '@intake24/common/types/http/admin';
-import { Survey, User, UserSecurable } from '.';
-import { BaseModel } from '..';
+
+import BaseModel from '../model';
+
+import Survey from './survey';
+import User from './user';
+import UserSecurable from './user-securable';
 
 @Table({
   modelName: 'FAQ',

--- a/packages/db/src/models/system/feedback-scheme.ts
+++ b/packages/db/src/models/system/feedback-scheme.ts
@@ -33,8 +33,11 @@ import type {
 import { defaultMeals, defaultTopFoods } from '@intake24/common/feedback';
 
 import type { RecordVisibility } from '@intake24/common/security';
-import { Survey, User, UserSecurable } from '.';
-import { BaseModel } from '..';
+
+import BaseModel from '../model';
+import Survey from './survey';
+import User from './user';
+import UserSecurable from './user-securable';
 
 @Scopes(() => ({
   surveys: { include: [{ model: Survey }] },

--- a/packages/db/src/models/system/gen-user-counter.ts
+++ b/packages/db/src/models/system/gen-user-counter.ts
@@ -16,8 +16,8 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
-import { Survey } from '.';
 import BaseModel from '../model';
+import Survey from './survey';
 
 @Scopes(() => ({
   survey: { include: [{ model: Survey }] },

--- a/packages/db/src/models/system/job.ts
+++ b/packages/db/src/models/system/job.ts
@@ -18,8 +18,8 @@ import {
 
 import type { JobType, JobTypeParams } from '@intake24/common/types';
 
-import { User } from '.';
 import BaseModel from '../model';
+import User from './user';
 
 @Table({
   modelName: 'Job',

--- a/packages/db/src/models/system/language-translation.ts
+++ b/packages/db/src/models/system/language-translation.ts
@@ -11,8 +11,8 @@ import { BelongsTo, Column, CreatedAt, DataType, Table, UpdatedAt } from 'sequel
 import type { Application } from '@intake24/common/types';
 import type { LocaleMessageDictionary } from '@intake24/i18n';
 
-import { Language } from '.';
 import BaseModel from '../model';
+import Language from './language';
 
 @Table({
   modelName: 'LanguageTranslations',

--- a/packages/db/src/models/system/language.ts
+++ b/packages/db/src/models/system/language.ts
@@ -22,9 +22,12 @@ import {
 import type { RecordVisibility } from '@intake24/common/security';
 
 import type { TextDirection } from '@intake24/common/types';
-import { LanguageTranslation, User, UserSecurable } from '.';
 import BaseModel from '../model';
+import LanguageTranslation from './language-translation';
 import SystemLocale from './locale';
+
+import User from './user';
+import UserSecurable from './user-securable';
 
 @Scopes(() => ({
   public: {

--- a/packages/db/src/models/system/locale.ts
+++ b/packages/db/src/models/system/locale.ts
@@ -22,8 +22,11 @@ import {
 import type { RecordVisibility } from '@intake24/common/security';
 
 import type { TextDirection } from '@intake24/common/types';
-import { Language, Survey, User, UserSecurable } from '.';
 import BaseModel from '../model';
+import Language from './language';
+import Survey from './survey';
+import User from './user';
+import UserSecurable from './user-securable';
 
 @Scopes(() => ({
   list: {

--- a/packages/db/src/models/system/mfa-authenticator.ts
+++ b/packages/db/src/models/system/mfa-authenticator.ts
@@ -9,8 +9,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, CreatedAt, DataType, Table, UpdatedAt } from 'sequelize-typescript';
 
-import { MFADevice } from '.';
 import BaseModel from '../model';
+import MFADevice from './mfa-device';
 
 @Table({
   modelName: 'MFAAuthenticator',

--- a/packages/db/src/models/system/mfa-device.ts
+++ b/packages/db/src/models/system/mfa-device.ts
@@ -20,8 +20,9 @@ import {
 
 import type { MFAProvider } from '@intake24/common/security';
 
-import { MFAAuthenticator, User } from '.';
 import BaseModel from '../model';
+import MFAAuthenticator from './mfa-authenticator';
+import User from './user';
 
 @DefaultScope(() => ({
   attributes: { exclude: ['secret'] },

--- a/packages/db/src/models/system/nutrient-type.ts
+++ b/packages/db/src/models/system/nutrient-type.ts
@@ -7,8 +7,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, ForeignKey, Scopes, Table } from 'sequelize-typescript';
 
-import { SystemNutrientUnit } from '.';
 import BaseModel from '../model';
+import SystemNutrientUnit from './nutrient-unit';
 
 @Scopes(() => ({
   unit: { include: [{ model: SystemNutrientUnit }] },

--- a/packages/db/src/models/system/nutrient-unit.ts
+++ b/packages/db/src/models/system/nutrient-unit.ts
@@ -7,8 +7,8 @@ import type {
 } from 'sequelize';
 import { Column, DataType, HasMany, Scopes, Table } from 'sequelize-typescript';
 
-import { SystemNutrientType } from '.';
 import BaseModel from '../model';
+import SystemNutrientType from './nutrient-type';
 
 @Scopes(() => ({
   nutrientTypes: { include: [{ model: SystemNutrientType }] },

--- a/packages/db/src/models/system/permission-role.ts
+++ b/packages/db/src/models/system/permission-role.ts
@@ -7,8 +7,9 @@ import type {
 } from 'sequelize';
 import { Column, CreatedAt, DataType, ForeignKey, Table, UpdatedAt } from 'sequelize-typescript';
 
-import { Permission, Role } from '.';
 import BaseModel from '../model';
+import Permission from './permission';
+import Role from './role';
 
 @Table({
   modelName: 'PermissionRole',

--- a/packages/db/src/models/system/permission-user.ts
+++ b/packages/db/src/models/system/permission-user.ts
@@ -7,8 +7,9 @@ import type {
 } from 'sequelize';
 import { Column, CreatedAt, DataType, ForeignKey, Table, UpdatedAt } from 'sequelize-typescript';
 
-import { Permission, User } from '.';
 import BaseModel from '../model';
+import Permission from './permission';
+import User from './user';
 
 @Table({
   modelName: 'PermissionUser',

--- a/packages/db/src/models/system/permission.ts
+++ b/packages/db/src/models/system/permission.ts
@@ -22,8 +22,11 @@ import {
 
 import { aclConfig } from '@intake24/common-backend';
 
-import { PermissionRole, PermissionUser, Role, User } from '.';
 import BaseModel from '../model';
+import PermissionRole from './permission-role';
+import PermissionUser from './permission-user';
+import Role from './role';
+import User from './user';
 
 export async function addPermissionsToAdmin(permissions: Permission[], options: { transaction?: Transaction } = {}): Promise<void> {
   const { transaction } = options;

--- a/packages/db/src/models/system/personal-access-token.ts
+++ b/packages/db/src/models/system/personal-access-token.ts
@@ -8,8 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, CreatedAt, DataType, Table, UpdatedAt } from 'sequelize-typescript';
 
-import { User } from '.';
 import BaseModel from '../model';
+import User from './user';
 
 @Table({
   modelName: 'PersonalAccessToken',

--- a/packages/db/src/models/system/refresh-token.ts
+++ b/packages/db/src/models/system/refresh-token.ts
@@ -17,8 +17,8 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
-import { User } from '.';
 import BaseModel from '../model';
+import User from './user';
 
 @Scopes(() => ({
   user: { include: [{ model: User }] },

--- a/packages/db/src/models/system/role-user.ts
+++ b/packages/db/src/models/system/role-user.ts
@@ -16,8 +16,9 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
-import { Role, User } from '.';
 import BaseModel from '../model';
+import Role from './role';
+import User from './user';
 
 @Table({
   modelName: 'RoleUser',

--- a/packages/db/src/models/system/role.ts
+++ b/packages/db/src/models/system/role.ts
@@ -17,8 +17,11 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
-import { Permission, PermissionRole, RoleUser, User } from '.';
 import BaseModel from '../model';
+import Permission from './permission';
+import PermissionRole from './permission-role';
+import RoleUser from './role-user';
+import User from './user';
 
 @Scopes(() => ({
   list: { attributes: ['id', 'name', 'displayName'], order: [['name', 'ASC']] },

--- a/packages/db/src/models/system/sign-in-log.ts
+++ b/packages/db/src/models/system/sign-in-log.ts
@@ -8,8 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 
-import { User } from '.';
 import BaseModel from '../model';
+import User from './user';
 
 @Scopes(() => ({
   user: { include: [{ model: User }] },

--- a/packages/db/src/models/system/survey-scheme.ts
+++ b/packages/db/src/models/system/survey-scheme.ts
@@ -23,8 +23,10 @@ import type { RecordVisibility } from '@intake24/common/security';
 import type { ExportSection, Meal, RecallPrompts, SchemeSettings } from '@intake24/common/surveys';
 
 import { defaultExport, defaultMeals, defaultPrompts, defaultSchemeSettings } from '@intake24/common/surveys';
-import { Survey, User, UserSecurable } from '.';
-import { BaseModel } from '..';
+import BaseModel from '../model';
+import Survey from './survey';
+import User from './user';
+import UserSecurable from './user-securable';
 
 @Scopes(() => ({
   list: { attributes: ['id', 'name'], order: [['name', 'ASC']] },

--- a/packages/db/src/models/system/survey-submission-custom-field.ts
+++ b/packages/db/src/models/system/survey-submission-custom-field.ts
@@ -7,8 +7,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 
-import { SurveySubmission } from '.';
 import BaseModel from '../model';
+import SurveySubmission from './survey-submission';
 
 @Scopes(() => ({
   submission: { include: [{ model: SurveySubmission }] },

--- a/packages/db/src/models/system/survey-submission-external-source.ts
+++ b/packages/db/src/models/system/survey-submission-external-source.ts
@@ -10,11 +10,10 @@ import { BelongsTo, Column, DataType, Table } from 'sequelize-typescript';
 
 import type { ExternalSource } from '@intake24/common/prompts';
 
-import {
-  SurveySubmissionFood,
-  SurveySubmissionMissingFood,
-} from '.';
 import BaseModel from '../model';
+import SurveySubmissionFood from './survey-submission-food';
+
+import SurveySubmissionMissingFood from './survey-submission-missing-food';
 
 @Table({
   modelName: 'SurveySubmissionExternalSource',

--- a/packages/db/src/models/system/survey-submission-field.ts
+++ b/packages/db/src/models/system/survey-submission-field.ts
@@ -7,8 +7,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 
-import { SurveySubmissionFood } from '.';
 import BaseModel from '../model';
+import SurveySubmissionFood from './survey-submission-food';
 
 @Scopes(() => ({
   food: { include: [{ model: SurveySubmissionFood }] },

--- a/packages/db/src/models/system/survey-submission-food-custom-field.ts
+++ b/packages/db/src/models/system/survey-submission-food-custom-field.ts
@@ -7,8 +7,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 
-import { SurveySubmissionFood } from '.';
 import BaseModel from '../model';
+import SurveySubmissionFood from './survey-submission-food';
 
 @Scopes(() => ({
   food: { include: [{ model: SurveySubmissionFood }] },

--- a/packages/db/src/models/system/survey-submission-food.ts
+++ b/packages/db/src/models/system/survey-submission-food.ts
@@ -10,15 +10,13 @@ import { BelongsTo, Column, DataType, HasMany, Scopes, Table } from 'sequelize-t
 
 import type { PortionSizeMethodId } from '@intake24/common/surveys';
 
-import {
-  SurveySubmissionExternalSource,
-  SurveySubmissionField,
-  SurveySubmissionFoodCustomField,
-  SurveySubmissionMeal,
-  SurveySubmissionNutrient,
-  SurveySubmissionPortionSizeField,
-} from '.';
 import BaseModel from '../model';
+import SurveySubmissionExternalSource from './survey-submission-external-source';
+import SurveySubmissionField from './survey-submission-field';
+import SurveySubmissionFoodCustomField from './survey-submission-food-custom-field';
+import SurveySubmissionMeal from './survey-submission-meal';
+import SurveySubmissionNutrient from './survey-submission-nutrient';
+import SurveySubmissionPortionSizeField from './survey-submission-portion-size-field';
 
 @Scopes(() => ({
   meal: { include: [{ model: SurveySubmissionMeal }] },

--- a/packages/db/src/models/system/survey-submission-meal-custom-field.ts
+++ b/packages/db/src/models/system/survey-submission-meal-custom-field.ts
@@ -7,8 +7,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 
-import { SurveySubmissionMeal } from '.';
 import BaseModel from '../model';
+import SurveySubmissionMeal from './survey-submission-meal';
 
 @Scopes(() => ({
   meal: { include: [{ model: SurveySubmissionMeal }] },

--- a/packages/db/src/models/system/survey-submission-meal.ts
+++ b/packages/db/src/models/system/survey-submission-meal.ts
@@ -7,13 +7,11 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, HasMany, Scopes, Table } from 'sequelize-typescript';
 
-import {
-  SurveySubmission,
-  SurveySubmissionFood,
-  SurveySubmissionMealCustomField,
-  SurveySubmissionMissingFood,
-} from '.';
 import BaseModel from '../model';
+import SurveySubmission from './survey-submission';
+import SurveySubmissionFood from './survey-submission-food';
+import SurveySubmissionMealCustomField from './survey-submission-meal-custom-field';
+import SurveySubmissionMissingFood from './survey-submission-missing-food';
 
 @Scopes(() => ({
   submission: { include: [{ model: SurveySubmission }] },

--- a/packages/db/src/models/system/survey-submission-missing-food.ts
+++ b/packages/db/src/models/system/survey-submission-missing-food.ts
@@ -8,8 +8,9 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, HasMany, Scopes, Table } from 'sequelize-typescript';
 
-import { SurveySubmissionExternalSource, SurveySubmissionMeal } from '.';
 import BaseModel from '../model';
+import SurveySubmissionExternalSource from './survey-submission-external-source';
+import SurveySubmissionMeal from './survey-submission-meal';
 
 @Scopes(() => ({
   meal: { include: [{ model: SurveySubmissionMeal }] },

--- a/packages/db/src/models/system/survey-submission-nutrient.ts
+++ b/packages/db/src/models/system/survey-submission-nutrient.ts
@@ -7,8 +7,9 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 
-import { SurveySubmissionFood, SystemNutrientType } from '.';
 import BaseModel from '../model';
+import SystemNutrientType from './nutrient-type';
+import SurveySubmissionFood from './survey-submission-food';
 
 @Scopes(() => ({
   food: { include: [{ model: SurveySubmissionFood }] },

--- a/packages/db/src/models/system/survey-submission-portion-size-field.ts
+++ b/packages/db/src/models/system/survey-submission-portion-size-field.ts
@@ -7,8 +7,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 
-import { SurveySubmissionFood } from '.';
 import BaseModel from '../model';
+import SurveySubmissionFood from './survey-submission-food';
 
 @Scopes(() => ({
   food: { include: [{ model: SurveySubmissionFood }] },

--- a/packages/db/src/models/system/survey-submission.ts
+++ b/packages/db/src/models/system/survey-submission.ts
@@ -17,8 +17,11 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
-import { Survey, SurveySubmissionCustomField, SurveySubmissionMeal, User } from '.';
 import BaseModel from '../model';
+import Survey from './survey';
+import SurveySubmissionCustomField from './survey-submission-custom-field';
+import SurveySubmissionMeal from './survey-submission-meal';
+import User from './user';
 
 @Scopes(() => ({
   survey: { include: [{ model: Survey }] },

--- a/packages/db/src/models/system/survey.ts
+++ b/packages/db/src/models/system/survey.ts
@@ -34,21 +34,20 @@ import {
   defaultSessionSettings,
 } from '@intake24/common/surveys';
 import type { Notification } from '@intake24/common/types';
-import {
-  ClientErrorReport,
-  FAQ,
-  FeedbackScheme,
-  GenUserCounter,
-  Permission,
-  SurveyScheme,
-  SurveySubmission,
-  SystemLocale,
-  User,
-  UserSecurable,
-  UserSurveyAlias,
-  UserSurveySession,
-} from '.';
+
 import BaseModel from '../model';
+import ClientErrorReport from './client-error-report';
+import FAQ from './faq';
+import FeedbackScheme from './feedback-scheme';
+import GenUserCounter from './gen-user-counter';
+import SystemLocale from './locale';
+import Permission from './permission';
+import SurveyScheme from './survey-scheme';
+import SurveySubmission from './survey-submission';
+import User from './user';
+import UserSecurable from './user-securable';
+import UserSurveyAlias from './user-survey-alias';
+import UserSurveySession from './user-survey-session';
 
 @Scopes(() => ({
   counter: { include: [{ model: GenUserCounter }] },

--- a/packages/db/src/models/system/user-custom-field.ts
+++ b/packages/db/src/models/system/user-custom-field.ts
@@ -8,8 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, Scopes, Table } from 'sequelize-typescript';
 
-import { User } from '.';
 import BaseModel from '../model';
+import User from './user';
 
 @Scopes(() => ({
   user: { include: [{ model: User }] },

--- a/packages/db/src/models/system/user-password-reset.ts
+++ b/packages/db/src/models/system/user-password-reset.ts
@@ -8,8 +8,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, CreatedAt, DataType, Table, UpdatedAt } from 'sequelize-typescript';
 
-import { User } from '.';
 import BaseModel from '../model';
+import User from './user';
 
 @Table({
   modelName: 'UserPasswordReset',

--- a/packages/db/src/models/system/user-password.ts
+++ b/packages/db/src/models/system/user-password.ts
@@ -7,8 +7,8 @@ import type {
 } from 'sequelize';
 import { BelongsTo, Column, DataType, ForeignKey, Table } from 'sequelize-typescript';
 
-import { User } from '.';
 import BaseModel from '../model';
+import User from './user';
 
 @Table({
   modelName: 'UserPassword',

--- a/packages/db/src/models/system/user-physical-data.ts
+++ b/packages/db/src/models/system/user-physical-data.ts
@@ -9,8 +9,8 @@ import { BelongsTo, Column, DataType, ForeignKey, Table } from 'sequelize-typesc
 
 import type { Sex, WeightTarget } from '@intake24/common/feedback';
 
-import { User } from '.';
 import BaseModel from '../model';
+import User from './user';
 
 @Table({
   modelName: 'UserPhysicalData',

--- a/packages/db/src/models/system/user-securable.ts
+++ b/packages/db/src/models/system/user-securable.ts
@@ -9,8 +9,8 @@ import { Column, CreatedAt, DataType, ForeignKey, Table, UpdatedAt } from 'seque
 
 import type { SecurableType } from '@intake24/common/security';
 
-import { User } from '.';
 import BaseModel from '../model';
+import User from './user';
 
 @Table({
   modelName: 'UserSecurable',

--- a/packages/db/src/models/system/user-subscription.ts
+++ b/packages/db/src/models/system/user-subscription.ts
@@ -17,8 +17,8 @@ import {
 } from 'sequelize-typescript';
 import type { Subscription, SubscriptionType } from '@intake24/common/types';
 
-import { User } from '.';
 import BaseModel from '../model';
+import User from './user';
 
 @Scopes(() => ({
   user: { include: [{ model: User }] },

--- a/packages/db/src/models/system/user-survey-alias.ts
+++ b/packages/db/src/models/system/user-survey-alias.ts
@@ -17,8 +17,9 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
-import { Survey, User } from '.';
 import BaseModel from '../model';
+import Survey from './survey';
+import User from './user';
 
 @Scopes(() => ({
   user: { include: [{ model: User }] },

--- a/packages/db/src/models/system/user-survey-rating.ts
+++ b/packages/db/src/models/system/user-survey-rating.ts
@@ -17,8 +17,9 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
-import { Survey, User } from '.';
 import BaseModel from '../model';
+import Survey from './survey';
+import User from './user';
 
 @Scopes(() => ({
   user: { include: [{ model: User }] },

--- a/packages/db/src/models/system/user-survey-session.ts
+++ b/packages/db/src/models/system/user-survey-session.ts
@@ -10,8 +10,10 @@ import { BelongsTo, Column, CreatedAt, DataType, Table, UpdatedAt } from 'sequel
 
 import type { SurveyState } from '@intake24/common/surveys';
 
-import { Survey, User, UserSurveyAlias } from '.';
 import BaseModel from '../model';
+import Survey from './survey';
+import User from './user';
+import UserSurveyAlias from './user-survey-alias';
 
 @Table({
   modelName: 'UserSurveySession',

--- a/packages/db/src/models/system/user.ts
+++ b/packages/db/src/models/system/user.ts
@@ -19,31 +19,29 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
-import {
-  ClientErrorReport,
-  FeedbackScheme,
-  Job,
-  MFADevice,
-  Permission,
-  PermissionUser,
-  PersonalAccessToken,
-  RefreshToken,
-  Role,
-  RoleUser,
-  SignInLog,
-  Survey,
-  SurveyScheme,
-  SurveySubmission,
-  UserCustomField,
-  UserPassword,
-  UserPasswordReset,
-  UserPhysicalData,
-  UserSecurable,
-  UserSubscription,
-  UserSurveyAlias,
-  UserSurveySession,
-} from '.';
 import BaseModel from '../model';
+import ClientErrorReport from './client-error-report';
+import FeedbackScheme from './feedback-scheme';
+import Job from './job';
+import MFADevice from './mfa-device';
+import Permission from './permission';
+import PermissionUser from './permission-user';
+import PersonalAccessToken from './personal-access-token';
+import RefreshToken from './refresh-token';
+import Role from './role';
+import RoleUser from './role-user';
+import SignInLog from './sign-in-log';
+import Survey from './survey';
+import SurveyScheme from './survey-scheme';
+import SurveySubmission from './survey-submission';
+import UserCustomField from './user-custom-field';
+import UserPassword from './user-password';
+import UserPasswordReset from './user-password-reset';
+import UserPhysicalData from './user-physical-data';
+import UserSecurable from './user-securable';
+import UserSubscription from './user-subscription';
+import UserSurveyAlias from './user-survey-alias';
+import UserSurveySession from './user-survey-session';
 
 @Scopes(() => ({
   aliases: { include: [{ model: UserSurveyAlias, separate: true }] },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,6 +499,9 @@ importers:
       '@types/webpack-env':
         specifier: ^1.18.8
         version: 1.18.8
+      circular-dependency-plugin:
+        specifier: ^5.2.2
+        version: 5.2.2(webpack@5.102.1)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -5621,6 +5624,12 @@ packages:
   ci-info@4.3.1:
     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
     engines: {node: '>=8'}
+
+  circular-dependency-plugin@5.2.2:
+    resolution: {integrity: sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      webpack: '>=4.0.1'
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
@@ -16589,6 +16598,10 @@ snapshots:
       zod: 3.25.76
 
   ci-info@4.3.1: {}
+
+  circular-dependency-plugin@5.2.2(webpack@5.102.1):
+    dependencies:
+      webpack: 5.102.1(webpack-cli@6.0.1)
 
   citty@0.1.6:
     dependencies:


### PR DESCRIPTION
1. Added circular-dependency-plugin for Webpack

Plugin is configured to report circular imports as warnings during Webpack build process (only in dev configuration)

Added a custom (fairly hacky) filter for circular-dependency-plugin to identify types used in Sequelize models decorators (`@HasMany`, `@BelongsTo` etc.) and suppress circular import warnings because this is safe

2. Cleaned up circular imports in Sequelize models: changed imports from barrel files to direct local imports
3. Resolved some circular dependencies between IoC/service definition files

