### PR TITLE
Fix migration scripts for default snapshots

### DIFF
--- a/apps/cli/src/commands/init/init-db-system.ts
+++ b/apps/cli/src/commands/init/init-db-system.ts
@@ -406,8 +406,8 @@ export default async (): Promise<void> => {
       }),
       container: () => text({
         message: 'Enter the Docker container name:',
-        initialValue: 'intake24-db',
-        placeholder: 'intake24-db',
+        initialValue: 'db',
+        placeholder: 'db',
       }),
       postgresUser: () => text({
         message: 'Enter the Postgres user name:',
@@ -443,8 +443,8 @@ export default async (): Promise<void> => {
       }),
       container: () => text({
         message: 'Enter the Docker container name:',
-        initialValue: 'intake24-db',
-        placeholder: 'intake24-db',
+        initialValue: 'db',
+        placeholder: 'db',
       }),
       postgresUser: () => text({
         message: 'Enter the Postgres user name:',

--- a/packages/db/sequelize/foods/migrations/20260202160000-pathways-to-enum-array.js
+++ b/packages/db/sequelize/foods/migrations/20260202160000-pathways-to-enum-array.js
@@ -5,22 +5,30 @@ export default {
       // Sequelize's sync will create separate enums following the naming convention: enum_<table>_<column>
       // Match that behaviour here to keep it compatible with Kysely (a single shared enum makes more sense otherwise)
       await queryInterface.sequelize.query(
-        `CREATE TYPE enum_category_portion_size_methods_pathways AS ENUM ('addon', 'afp', 'recipe', 'search');`,
+        `DO $$ BEGIN
+          CREATE TYPE enum_category_portion_size_methods_pathways AS ENUM ('addon', 'afp', 'recipe', 'search');
+        EXCEPTION
+          WHEN duplicate_object THEN null;
+        END $$;`,
         { transaction },
       );
 
       await queryInterface.sequelize.query(
-        `CREATE TYPE enum_food_portion_size_methods_pathways AS ENUM ('addon', 'afp', 'recipe', 'search');`,
+        `DO $$ BEGIN
+          CREATE TYPE enum_food_portion_size_methods_pathways AS ENUM ('addon', 'afp', 'recipe', 'search');
+        EXCEPTION
+          WHEN duplicate_object THEN null;
+        END $$;`,
         { transaction },
       );
 
       await queryInterface.sequelize.query(
-        `ALTER TABLE category_portion_size_methods ADD COLUMN pathways_temp enum_category_portion_size_methods_pathways[];`,
+        `ALTER TABLE category_portion_size_methods ADD COLUMN IF NOT EXISTS pathways_temp enum_category_portion_size_methods_pathways[];`,
         { transaction },
       );
 
       await queryInterface.sequelize.query(
-        `ALTER TABLE food_portion_size_methods ADD COLUMN pathways_temp enum_food_portion_size_methods_pathways[];`,
+        `ALTER TABLE food_portion_size_methods ADD COLUMN IF NOT EXISTS pathways_temp enum_food_portion_size_methods_pathways[];`,
         { transaction },
       );
 

--- a/packages/db/sequelize/system/migrations/20260202145349-media_disk_column_to_enum.js
+++ b/packages/db/sequelize/system/migrations/20260202145349-media_disk_column_to_enum.js
@@ -5,7 +5,11 @@ export default {
     // and it appears there is no way to change it in the Sequelize model
     queryInterface.sequelize.transaction(async (transaction) => {
       await queryInterface.sequelize.query(
-        `CREATE TYPE enum_media_disk AS ENUM ('public', 'private')`,
+        `DO $$ BEGIN
+          CREATE TYPE enum_media_disk AS ENUM ('public', 'private');
+        EXCEPTION
+          WHEN duplicate_object THEN null;
+        END $$;`,
         { transaction },
       );
 


### PR DESCRIPTION
Fix migration scripts and make it runs `pnpm db:migrate` command, even if columns such as `pathways_temp` or objects such as `enum_category_portion_size_methods_pathways` already exists.