### PR TITLE
feat(admin): add 'Hide anywhere' option to useInRecipes

### DIFF
--- a/apps/api/src/http/routers/category.router.ts
+++ b/apps/api/src/http/routers/category.router.ts
@@ -18,12 +18,13 @@ export function category() {
 
       return { status: 200, body: foods };
     },
-    contents: async ({ params, req }) => {
+    contents: async ({ params, query, req }) => {
       const { localeId, code } = params;
 
       const categoryContents = await req.scope.cradle.categoryContentsService.getCategoryContents(
         localeId,
         code,
+        query.recipe ?? false,
       );
 
       categoryContents.foods = await req.scope.cradle.foodThumbnailImageService.appendThumbnailUrls(categoryContents.foods);

--- a/apps/api/src/jobs/io/export/package-exporter.ts
+++ b/apps/api/src/jobs/io/export/package-exporter.ts
@@ -416,7 +416,7 @@ export class PackageExporter {
             readyMealOption: row.readyMealOption ?? undefined,
             reasonableAmount: row.reasonableAmount ?? undefined,
             sameAsBeforeOption: row.sameAsBeforeOption ?? undefined,
-            useInRecipes: (row.useInRecipes as 0 | 1 | 2 | null) ?? undefined,
+            useInRecipes: (row.useInRecipes as 0 | 1 | 2 | 3 | null) ?? undefined,
           },
           parentCategories: parentCategoryIndex[row.id] ?? [],
           portionSize: categoryPortionSizeMethodsIndex[row.id] ?? [],

--- a/apps/api/src/services/foods/category-contents.service.ts
+++ b/apps/api/src/services/foods/category-contents.service.ts
@@ -49,7 +49,7 @@ function categoryContentsService({
     return { id: category.id, code, name: category.name, icon: category.icon ?? undefined };
   };
 
-  const getCategoryContents = async (localeCode: string, code: string): Promise<CategoryContents> => {
+  const getCategoryContents = async (localeCode: string, code: string, recipe = false): Promise<CategoryContents> => {
     const [header, categories, foods] = await Promise.all([
       getCategoryHeader(localeCode, code),
       Category.findAll({
@@ -78,10 +78,21 @@ function categoryContentsService({
       }),
     ]);
 
+    const foodIds = foods.map(({ id }) => id);
+    const catIds = categories.map(({ id }) => id);
+    const [foodCache, categoryCache] = await Promise.all([
+      cachedParentCategoriesService.getFoodsCache(foodIds),
+      cachedParentCategoriesService.getCategoriesCache(catIds),
+    ]);
+
     return {
       header,
-      foods: filterUndefined(foods).sort((a, b) => a.name.localeCompare(b.name)),
-      subcategories: filterUndefined(categories).sort((a, b) => a.name.localeCompare(b.name)),
+      foods: filterUndefined(foods)
+        .filter(({ id }) => acceptForQuery(recipe, foodCache[id]?.attributes.useInRecipes))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+      subcategories: filterUndefined(categories)
+        .filter(({ id }) => acceptForQuery(recipe, categoryCache[id]?.attributes.useInRecipes))
+        .sort((a, b) => a.name.localeCompare(b.name)),
     };
   };
 

--- a/apps/api/src/services/foods/common.ts
+++ b/apps/api/src/services/foods/common.ts
@@ -9,6 +9,8 @@ export function acceptForQuery(recipe: boolean, attrOpt?: number): boolean {
       return !recipe;
     case useInRecipeTypes.USE_AS_RECIPE_INGREDIENT:
       return recipe;
+    case useInRecipeTypes.HIDE_ANYWHERE:
+      return false;
     default:
       return true;
   }

--- a/apps/survey/src/components/elements/FoodBrowser.vue
+++ b/apps/survey/src/components/elements/FoodBrowser.vue
@@ -216,6 +216,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  recipe: {
+    type: Boolean,
+    default: false,
+  },
   prompt: {
     type: Object as PropType<
       Prompts['associated-foods-prompt' | 'general-associated-foods-prompt' | 'food-search-prompt' | 'recipe-builder-prompt']
@@ -381,7 +385,7 @@ async function browseCategory(categoryCode: string | undefined, makeHistoryEntry
   tab.value = 'browse';
 
   try {
-    const contents = await categoriesService.contents(props.localeId, categoryCode);
+    const contents = await categoriesService.contents(props.localeId, categoryCode, props.recipe);
 
     requestInProgress.value = false;
     requestFailed.value = false;

--- a/apps/survey/src/components/prompts/standard/AssociatedFoodsPrompt.vue
+++ b/apps/survey/src/components/prompts/standard/AssociatedFoodsPrompt.vue
@@ -176,6 +176,7 @@
                     rootCategory: prompts[index].categoryCode,
                     section,
                     includeHidden: true,
+                    recipe: true,
                   }"
                   @food-missing="foodMissing(index)"
                   @food-selected="(food) => foodSelected(food, index)"

--- a/apps/survey/src/services/categories.service.ts
+++ b/apps/survey/src/services/categories.service.ts
@@ -3,9 +3,10 @@ import type { CategoryContents, CategoryHeader, CategorySearch } from '@intake24
 import { http } from '@intake24/ui';
 
 export default {
-  contents: async (localeId: string, code?: string) => {
+  contents: async (localeId: string, code?: string, recipe = false) => {
     const { data } = await http.get<CategoryContents>(
       code ? `locales/${localeId}/category-contents/${code}` : `locales/${localeId}/category-contents`,
+      { params: code && recipe ? { recipe: true } : undefined },
     );
     return data;
   },

--- a/packages/common/src/contracts/category.contract.ts
+++ b/packages/common/src/contracts/category.contract.ts
@@ -1,4 +1,5 @@
 import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
 
 import {
   categoryContents,
@@ -31,6 +32,9 @@ export const category = initContract().router({
   contents: {
     method: 'GET',
     path: '/locales/:localeId/category-contents/:code',
+    query: z.object({
+      recipe: z.coerce.boolean().optional(),
+    }),
     responses: {
       200: categoryContents,
     },

--- a/packages/common/src/types/foods.ts
+++ b/packages/common/src/types/foods.ts
@@ -6,6 +6,7 @@ export const useInRecipeTypes = {
   USE_ANYWHERE: 0,
   USE_AS_REGULAR_FOOD: 1,
   USE_AS_RECIPE_INGREDIENT: 2,
+  HIDE_ANYWHERE: 3,
 } as const;
 
 export type UseInRecipeType = (typeof useInRecipeTypes)[keyof typeof useInRecipeTypes];

--- a/packages/common/src/types/http/admin/attributes.ts
+++ b/packages/common/src/types/http/admin/attributes.ts
@@ -4,7 +4,7 @@ export const inheritableAttributes = z.object({
   readyMealOption: z.boolean().nullish(),
   sameAsBeforeOption: z.boolean().nullish(),
   reasonableAmount: z.number().nullish(),
-  useInRecipes: z.literal([0, 1, 2]).nullish(),
+  useInRecipes: z.literal([0, 1, 2, 3]).nullish(),
 });
 export type InheritableAttributes = z.infer<typeof inheritableAttributes>;
 
@@ -12,6 +12,6 @@ export const resolvedInheritableAttributes = z.object({
   readyMealOption: z.boolean(),
   sameAsBeforeOption: z.boolean(),
   reasonableAmount: z.number(),
-  useInRecipes: z.literal([0, 1, 2]),
+  useInRecipes: z.literal([0, 1, 2, 3]),
 });
 export type ResolvedInheritableAttributes = z.infer<typeof resolvedInheritableAttributes>;

--- a/packages/common/src/types/package/foods.ts
+++ b/packages/common/src/types/package/foods.ts
@@ -9,7 +9,7 @@ export const pkgV2InheritableAttributes = z.object({
   readyMealOption: z.boolean().optional(),
   sameAsBeforeOption: z.boolean().optional(),
   reasonableAmount: z.number().optional(),
-  useInRecipes: (z.literal(0).or(z.literal(1)).or(z.literal(2))).optional(),
+  useInRecipes: z.literal([0, 1, 2, 3]).optional(),
 });
 
 export const pkgV2PortionSizeMethodTypes = [

--- a/packages/i18n/src/admin/en/fdbs.json
+++ b/packages/i18n/src/admin/en/fdbs.json
@@ -64,7 +64,8 @@
       "_": "Use for recipes",
       "0": "Use anywhere",
       "1": "Use only as regular food",
-      "2": "Use only as recipe ingredient"
+      "2": "Use only as recipe ingredient",
+      "3": "Hide anywhere"
     }
   },
 

--- a/packages/i18n/src/admin/fr/fdbs.json
+++ b/packages/i18n/src/admin/fr/fdbs.json
@@ -61,6 +61,7 @@
       "0": "Utiliser partout",
       "1": "Utiliser seulement comme aliment",
       "2": "Utiliser seulement comme ingrédient d'une recette",
+      "3": "Masquer partout",
       "_": "Utiliser pour les recettes"
     }
   },


### PR DESCRIPTION
## Summary

Add a new `HIDE_ANYWHERE` (value `3`) option to the shared `useInRecipes` enum, allowing admin users to hide foods and categories from **all** user-facing browse/select flows.

Added new enum value
- `packages/common/src/types/foods.ts` — added `HIDE_ANYWHERE: 3`
- `packages/common/src/types/http/admin/attributes.ts` — expanded Zod literal union to include `3`

~### Cache invalidation fix~
~- `apps/api/src/services/admin/food.service.ts` — added `food-parent-cache` key to invalidation~
~- `apps/api/src/services/admin/category.service.ts` — added `category-parent-cache` key to invalidation~

~These cache keys were missing, causing stale resolved attributes after admin edits. This was a pre-existing issue but most visible with the new hide option.~