### PR TITLE
fix(cli): convert arrays to JsonValue before insert in init:db:system

### DIFF
--- a/apps/cli/src/commands/init/init-db-system.ts
+++ b/apps/cli/src/commands/init/init-db-system.ts
@@ -37,7 +37,7 @@ import {
   submitPrompt,
 } from '@intake24/common/prompts';
 import { defaultExport, defaultMeals, defaultSchemeSettings } from '@intake24/common/surveys';
-import { KyselyDatabases } from '@intake24/db';
+import { JsonValue, KyselyDatabases } from '@intake24/db';
 
 import initAssets from './init-assets';
 
@@ -245,9 +245,9 @@ async function initDefaultData(db: KyselyDatabases) {
   await db.system.insertInto('surveySchemes').values({
     name: 'Default',
     settings: defaultSchemeSettings,
-    meals: defaultMeals,
+    meals: new JsonValue(defaultMeals),
     prompts,
-    dataExport: defaultExport,
+    dataExport: new JsonValue(defaultExport),
     createdAt: now,
     updatedAt: now,
   }).executeTakeFirst();

--- a/packages/db/src/kysely/utils.ts
+++ b/packages/db/src/kysely/utils.ts
@@ -1,4 +1,4 @@
-import type { SelectQueryBuilder, Simplify, StringReference } from 'kysely';
+import type { Expression, OperationNode, SelectQueryBuilder, Simplify, StringReference } from 'kysely';
 
 import type { Pagination, PaginationMeta } from '@intake24/common/types/http';
 import type { PaginateQuery } from '@intake24/db';
@@ -88,4 +88,22 @@ export function values<R extends Record<string, unknown>, A extends string>(rows
   const aliasSql = sql`${sql.ref(alias)}(${sql.join(columns.map(sql.ref))})`;
 
   return sql<R>`(VALUES ${valuesSql})`.as<A>(aliasSql);
+}
+
+// https://kysely.dev/docs/recipes/extending-kysely#expression
+export class JsonValue<T> implements Expression<T> {
+  #value: T;
+
+  constructor(value: T) {
+    this.#value = value;
+  }
+
+  get expressionType(): T | undefined {
+    return undefined;
+  }
+
+  toOperationNode(): OperationNode {
+    const json = JSON.stringify(this.#value);
+    return sql`cast(${json} as jsonb)`.toOperationNode();
+  }
 }


### PR DESCRIPTION
Kysely does not automatically convert arrays into JSONB, so an explicit conversion is necessary prior to insertion.

See [Kysely documentation](https://kysely.dev/docs/recipes/extending-kysely#expression) for additional context.