### PR TITLE
Improve survey nutrient recalculation diagnostics and documentation

### DIFF
--- a/apps/api/__tests__/integration/jobs/surveys/survey-nutrients-recalculation.test.ts
+++ b/apps/api/__tests__/integration/jobs/surveys/survey-nutrients-recalculation.test.ts
@@ -108,6 +108,10 @@ export default () => {
     let recordBField: NutrientTableRecordField | null = null;
     let food: Food | null = null;
     let foodNutrient: FoodNutrient | null = null;
+    let nutrientTable2: NutrientTable | null = null;
+    let recordC: NutrientTableRecord | null = null;
+    let recordCNutrient: NutrientTableRecordNutrient | null = null;
+    let recordCField: NutrientTableRecordField | null = null;
     let submissionFood: SurveySubmissionFood | null = null;
     let submissionMeal: SurveySubmissionMeal | null = null;
     let submission: SurveySubmission | null = null;
@@ -152,6 +156,10 @@ export default () => {
         recordA,
         recordB,
         nutrientTable,
+        recordCNutrient,
+        recordCField,
+        recordC,
+        nutrientTable2,
         food,
         dbJob,
       ]);
@@ -167,6 +175,10 @@ export default () => {
       recordA = null;
       recordB = null;
       nutrientTable = null;
+      recordCNutrient = null;
+      recordCField = null;
+      recordC = null;
+      nutrientTable2 = null;
       food = null;
       dbJob = null;
     });
@@ -748,6 +760,178 @@ export default () => {
 
       // Cleanup extra nutrient
       await recordBNutrient2.destroy();
+    });
+
+    /**
+     * Setup for cross-FCT scenarios (1+2):
+     * - NT1/recordA: the original FCT the food was submitted with
+     * - NT2/recordC: a different FCT the food mapping is later switched to
+     * Scenarios 3-6 test how each recalculation mode handles this cross-FCT situation.
+     */
+    const setupFoodWithDifferentNutrientTables = async () => {
+      const { nutrientTableId: nutrientTableId1, foodCode } = await setupFoodAndNutrients();
+
+      const nutrientTableId2 = `NT2${Date.now()}`;
+      nutrientTable2 = await NutrientTable.create({
+        id: nutrientTableId2,
+        description: 'Test nutrient table 2 (different FCT)',
+      });
+
+      recordC = await NutrientTableRecord.create({
+        nutrientTableId: nutrientTableId2,
+        nutrientTableRecordId: 'C',
+        name: 'Record C',
+        localName: 'Record C',
+      });
+
+      recordCNutrient = await NutrientTableRecordNutrient.create({
+        nutrientTableRecordId: recordC.id,
+        nutrientTypeId: '1',
+        unitsPer100g: 200,
+      });
+
+      recordCField = await NutrientTableRecordField.create({
+        nutrientTableRecordId: recordC.id,
+        name: 'sub_group_code',
+        value: 'FCT2_CODE',
+      });
+
+      return { nutrientTableId1, nutrientTableId2, foodCode };
+    };
+
+    describe('cross FCT (different nutrient tables)', () => {
+      /**
+       * Scenario 3: values-only w/o syncFields
+       * Food submitted with NT1/A (scenario 1), food mapping later switched to NT2/C (scenario 2).
+       * Recalculation must use the STORED reference (NT1/A), update existing nutrient values
+       * from that record, and NOT add or remove nutrient codes.
+       * Nutrients missing from recordA are zeroed out (not removed).
+       */
+      it('values-only w/o syncFields keeps stored FCT reference and zeroes unresolvable nutrients without adding or removing codes', async () => {
+        const { nutrientTableId1, foodCode } = await setupFoodWithDifferentNutrientTables();
+
+        // Submission has nutrient1 and nutrient2; recordA only has nutrient1
+        await submissionFood!.update({ nutrients: { 1: 100, 2: 200 } });
+
+        // Scenario 2: food mapping switched to NT2/recordC (different FCT)
+        await foodNutrient!.destroy();
+        foodNutrient = await FoodNutrient.create({
+          foodId: food!.id,
+          nutrientTableRecordId: recordC!.id,
+        });
+
+        await runRecalculationJob({ surveyId: surveyId(), mode: 'values-only' });
+
+        const refreshed = await SurveySubmissionFood.findByPk(submissionFood!.id);
+
+        // Stays on stored FCT (NT1/A), ignores new mapping to NT2/C
+        expect(refreshed?.nutrientTableId).toBe(nutrientTableId1);
+        expect(refreshed?.nutrientTableCode).toBe('A');
+        // Nutrient 1 updated from recordA (50); nutrient 2 zeroed (not in recordA, preserved since syncFields=false)
+        expect(refreshed?.nutrients).toEqual({ 1: 50, 2: 0 });
+        expectFoodIdentityUnchanged(refreshed, foodCode);
+      });
+
+      /**
+       * Scenario 4: values-only + syncFields
+       * Same cross-FCT setup. Recalculation still uses the STORED reference (NT1/A),
+       * but syncFields=true removes nutrient codes not present in recordA.
+       */
+      it('values-only + syncFields keeps stored FCT reference and removes nutrient codes not in stored record', async () => {
+        const { nutrientTableId1, foodCode } = await setupFoodWithDifferentNutrientTables();
+
+        // Submission has nutrient1 and nutrient2; recordA only has nutrient1
+        await submissionFood!.update({ nutrients: { 1: 100, 2: 200 } });
+
+        // Scenario 2: food mapping switched to NT2/recordC (different FCT)
+        await foodNutrient!.destroy();
+        foodNutrient = await FoodNutrient.create({
+          foodId: food!.id,
+          nutrientTableRecordId: recordC!.id,
+        });
+
+        await runRecalculationJob({ surveyId: surveyId(), mode: 'values-only', syncFields: true });
+
+        const refreshed = await SurveySubmissionFood.findByPk(submissionFood!.id);
+
+        // Stays on stored FCT (NT1/A), ignores new mapping to NT2/C
+        expect(refreshed?.nutrientTableId).toBe(nutrientTableId1);
+        expect(refreshed?.nutrientTableCode).toBe('A');
+        // Nutrient 1 updated from recordA (50); nutrient 2 REMOVED (not in recordA, syncFields=true removes it)
+        expect(refreshed?.nutrients).toEqual({ 1: 50 });
+        expectFoodIdentityUnchanged(refreshed, foodCode);
+      });
+
+      /**
+       * Scenario 5: values-and-codes w/o syncFields
+       * Food mapping switched to NT2/C. Recalculation follows the NEW mapping (NT2/C),
+       * updating nutrientTableId and nutrientTableCode, but does NOT add or remove nutrient codes.
+       * Nutrients missing from recordC are zeroed out (not removed).
+       */
+      it('values-and-codes w/o syncFields updates to new FCT mapping but does not add or remove nutrient codes', async () => {
+        const { nutrientTableId2, foodCode } = await setupFoodWithDifferentNutrientTables();
+
+        // Submission has nutrient1 and nutrient2; recordC only has nutrient1
+        await submissionFood!.update({ nutrients: { 1: 100, 2: 200 } });
+
+        // Scenario 2: food mapping switched to NT2/recordC (different FCT)
+        await foodNutrient!.destroy();
+        foodNutrient = await FoodNutrient.create({
+          foodId: food!.id,
+          nutrientTableRecordId: recordC!.id,
+        });
+
+        await runRecalculationJob({ surveyId: surveyId(), mode: 'values-and-codes' });
+
+        const refreshed = await SurveySubmissionFood.findByPk(submissionFood!.id);
+
+        // Updated to new FCT (NT2/C)
+        expect(refreshed?.nutrientTableId).toBe(nutrientTableId2);
+        expect(refreshed?.nutrientTableCode).toBe('C');
+        // Nutrient 1 updated from recordC (200); nutrient 2 zeroed (not in recordC, syncFields=false preserves key)
+        expect(refreshed?.nutrients).toEqual({ 1: 200, 2: 0 });
+        expect(refreshed?.fields).toEqual({ sub_group_code: 'FCT2_CODE' });
+        expectFoodIdentityUnchanged(refreshed, foodCode);
+      });
+
+      /**
+       * Scenario 6: values-and-codes + syncFields
+       * Food mapping switched to NT2/C. Recalculation follows the NEW mapping (NT2/C),
+       * updates nutrientTableId and nutrientTableCode, AND adds or removes nutrient codes
+       * to fully match the new record's nutrient set.
+       */
+      it('values-and-codes + syncFields updates to new FCT mapping and fully syncs nutrient codes', async () => {
+        const { nutrientTableId2, foodCode } = await setupFoodWithDifferentNutrientTables();
+
+        // Add nutrient2 to recordC so NT2/C has both nutrient1 (200) and nutrient2 (300)
+        const recordCNutrient2 = await NutrientTableRecordNutrient.create({
+          nutrientTableRecordId: recordC!.id,
+          nutrientTypeId: '2',
+          unitsPer100g: 300,
+        });
+
+        // Submission has only nutrient1; syncFields will add nutrient2 from NT2/C
+        // Scenario 2: food mapping switched to NT2/recordC (different FCT)
+        await foodNutrient!.destroy();
+        foodNutrient = await FoodNutrient.create({
+          foodId: food!.id,
+          nutrientTableRecordId: recordC!.id,
+        });
+
+        await runRecalculationJob({ surveyId: surveyId(), mode: 'values-and-codes', syncFields: true });
+
+        const refreshed = await SurveySubmissionFood.findByPk(submissionFood!.id);
+
+        // Updated to new FCT (NT2/C)
+        expect(refreshed?.nutrientTableId).toBe(nutrientTableId2);
+        expect(refreshed?.nutrientTableCode).toBe('C');
+        // syncFields=true: nutrient1 updated from recordC (200), nutrient2 ADDED from recordC (300)
+        expect(refreshed?.nutrients).toEqual({ 1: 200, 2: 300 });
+        expect(refreshed?.fields).toEqual({ sub_group_code: 'FCT2_CODE' });
+        expectFoodIdentityUnchanged(refreshed, foodCode);
+
+        await recordCNutrient2.destroy();
+      });
     });
 
     it('recalculates in batches when there are more than 100 submission foods', async () => {

--- a/apps/api/src/jobs/surveys/survey-nutrients-recalculation.ts
+++ b/apps/api/src/jobs/surveys/survey-nutrients-recalculation.ts
@@ -4,9 +4,13 @@ import type { IoC } from '@intake24/api/ioc';
 import type { Dictionary } from '@intake24/common/types';
 import type { NutrientTableRecordField, NutrientTableRecordNutrient } from '@intake24/db';
 
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
 import { Op } from 'sequelize';
 
 import { NotFoundError } from '@intake24/api/http/errors';
+import { addTime } from '@intake24/api/util';
 import {
   Job as DbJob,
   Food as FoodModel,
@@ -45,9 +49,18 @@ type UpdateRecord = {
 };
 
 type ProcessFoodResult
-  = { type: 'skipped'; error: boolean }
+  = { type: 'skipped'; error: false }
+    | { type: 'skipped'; error: true; reason: string }
     | { type: 'cleared'; record: UpdateRecord }
     | { type: 'updated'; record: UpdateRecord; nutrientCodeUpdated: boolean; fieldsAdded: number; fieldsRemoved: number };
+
+interface SkippedErrorEntry {
+  foodCode: string;
+  locale: string;
+  nutrientTableId: string;
+  nutrientTableCode: string;
+  reason: string;
+}
 
 interface RecalculationFlags {
   shouldUpdateNutrientCodes: boolean;
@@ -84,9 +97,12 @@ export default class SurveyNutrientsRecalculation extends BaseJob<'SurveyNutrien
     errors: 0,
   };
 
-  constructor({ kyselyDb, logger }: Pick<IoC, 'kyselyDb' | 'logger'>) {
+  private readonly fsConfig;
+
+  constructor({ fsConfig, kyselyDb, logger }: Pick<IoC, 'fsConfig' | 'kyselyDb' | 'logger'>) {
     super({ logger });
 
+    this.fsConfig = fsConfig;
     this.kyselyDb = kyselyDb;
   }
 
@@ -122,14 +138,34 @@ export default class SurveyNutrientsRecalculation extends BaseJob<'SurveyNutrien
     this.logger.debug('Job started.', { params: this.params });
 
     this.resetStats();
-    await this.recalculate();
+    const skippedErrors = await this.recalculate();
 
     const isDryRun = this.params.mode === 'none';
     const prefix = isDryRun ? 'DRY RUN - NO DATA WAS MODIFIED. ' : '';
-    const summary = `${prefix}Recalculation completed. Total: ${this.stats.totalProcessed}, Updated: ${this.stats.updated}, Skipped: ${this.stats.skipped}, Nutrient codes updated: ${this.stats.nutrientCodesUpdated}, Fields added: ${this.stats.fieldsAdded}, Fields removed: ${this.stats.fieldsRemoved}, Cleared due to missing records: ${this.stats.clearedDueToMissingRecords}, Errors: ${this.stats.errors}`;
+
+    const errorNote = this.stats.errors > 0
+      ? ` ${this.stats.errors} food(s) were skipped because they are not defined in the foods DB for their submission locale — download the error log for details.`
+      : '';
+
+    const summary = `${prefix}Recalculation completed. Total: ${this.stats.totalProcessed}, Updated: ${this.stats.updated}, Skipped: ${this.stats.skipped}, Nutrient codes updated: ${this.stats.nutrientCodesUpdated}, Fields added: ${this.stats.fieldsAdded}, Fields removed: ${this.stats.fieldsRemoved}, Cleared due to missing records: ${this.stats.clearedDueToMissingRecords}, Errors: ${this.stats.errors}.${errorNote}`;
     this.logger.info(summary);
 
-    await this.dbJob.update({ message: summary });
+    const dbJobUpdate: Parameters<typeof this.dbJob.update>[0] = { message: summary };
+
+    if (skippedErrors.length > 0) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const filename = `intake24-${this.name}-errors-${this.params.surveyId}-${timestamp}.csv`;
+      const filepath = path.resolve(this.fsConfig.local.downloads, filename);
+      const csvHeader = 'food_code,locale,nutrient_table_id,nutrient_table_code,reason\n';
+      const csvRows = skippedErrors
+        .map(e => `${e.foodCode},${e.locale},${e.nutrientTableId},${e.nutrientTableCode},"${e.reason}"`)
+        .join('\n');
+      await writeFile(filepath, csvHeader + csvRows, 'utf-8');
+      dbJobUpdate.downloadUrl = filename;
+      dbJobUpdate.downloadUrlExpiresAt = addTime(this.fsConfig.urlExpiresAt);
+    }
+
+    await this.dbJob.update(dbJobUpdate);
 
     this.logger.debug('Job finished.');
   }
@@ -206,9 +242,16 @@ export default class SurveyNutrientsRecalculation extends BaseJob<'SurveyNutrien
       });
     }
 
-    // Add null entries for missing foods
+    // Add null entries for missing foods and warn — most common cause is a locale mismatch
+    // where the submission stores a locale (e.g. 'UK_current') that differs from the locale
+    // the food is defined under in the foods DB (e.g. 'UK_V3_2023').
     for (const code of foodCodes) {
       if (!mappingMap.has(code)) {
+        this.logger.warn(
+          'Food not found in foods DB for submission locale — NDB update may target a different locale. '
+          + 'Check that foods_nutrients was updated for the locale stored in survey_submission_foods.locale.',
+          { code, locale },
+        );
         mappingMap.set(code, null);
       }
     }
@@ -325,7 +368,7 @@ export default class SurveyNutrientsRecalculation extends BaseJob<'SurveyNutrien
         code: food.code,
         locale: food.locale,
       });
-      return { type: 'skipped', error: true };
+      return { type: 'skipped', error: true, reason: 'Food not found in foods DB for submission locale' };
     }
 
     // Handle food with warning (e.g., no nutrient mappings) — clear nutrients and fields
@@ -469,7 +512,7 @@ export default class SurveyNutrientsRecalculation extends BaseJob<'SurveyNutrien
     return { type: 'updated', record, nutrientCodeUpdated, fieldsAdded, fieldsRemoved };
   }
 
-  private async recalculate(batchSize = BATCH_SIZE) {
+  private async recalculate(batchSize = BATCH_SIZE): Promise<SkippedErrorEntry[]> {
     const { surveyId } = this.params;
     const flags = this.getRecalculationFlags();
 
@@ -486,7 +529,7 @@ export default class SurveyNutrientsRecalculation extends BaseJob<'SurveyNutrien
 
     if (total === 0) {
       this.logger.info('No foods found for survey, completing successfully.');
-      return;
+      return [];
     }
 
     this.initProgress(total);
@@ -495,6 +538,7 @@ export default class SurveyNutrientsRecalculation extends BaseJob<'SurveyNutrien
 
     // Persist across batches to avoid re-fetching the same food codes
     const currentMappings = new Map<string, FoodMapping | null>();
+    const skippedErrors: SkippedErrorEntry[] = [];
 
     for (const offset of offsets) {
       const limit = Math.min(batchSize, total - offset);
@@ -619,8 +663,16 @@ export default class SurveyNutrientsRecalculation extends BaseJob<'SurveyNutrien
         switch (result.type) {
           case 'skipped':
             batchSkipped++;
-            if (result.error)
+            if (result.error) {
               this.stats.errors++;
+              skippedErrors.push({
+                foodCode: food.code,
+                locale: food.locale,
+                nutrientTableId: food.nutrientTableId ?? '',
+                nutrientTableCode: food.nutrientTableCode ?? '',
+                reason: result.reason,
+              });
+            }
             break;
           case 'cleared':
             records.push(result.record);
@@ -681,5 +733,7 @@ export default class SurveyNutrientsRecalculation extends BaseJob<'SurveyNutrien
 
       await this.incrementProgress(limit);
     }
+
+    return skippedErrors;
   }
 }

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -21,6 +21,23 @@ export default defineConfig({
 
   vite: { server: { port: 8400 } },
 
+  markdown: {
+    config(md) {
+      const defaultFence = md.renderer.rules.fence!;
+
+      md.renderer.rules.fence = (tokens, idx, options, env, self) => {
+        const token = tokens[idx];
+
+        if (token.info.trim() !== 'mermaid')
+          return defaultFence(tokens, idx, options, env, self);
+
+        const graph = encodeURIComponent(token.content);
+
+        return `<ClientOnly><MermaidDiagram graph="${graph}" /></ClientOnly>`;
+      };
+    },
+  },
+
   themeConfig: {
     logo: '/icons/pwa-512x512.png',
     nav,

--- a/apps/docs/.vitepress/sidebar.ts
+++ b/apps/docs/.vitepress/sidebar.ts
@@ -234,6 +234,10 @@ export const sidebar = {
           link: '/admin/foods/nutrient-tables',
         },
         {
+          text: 'Nutrient data model',
+          link: '/admin/foods/nutrient-data-model',
+        },
+        {
           text: 'Nutrient types',
           link: '/admin/foods/nutrient-types',
         },

--- a/apps/docs/.vitepress/theme/MermaidDiagram.vue
+++ b/apps/docs/.vitepress/theme/MermaidDiagram.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import mermaid from 'mermaid';
+import { onMounted, ref, watch } from 'vue';
+
+const props = defineProps<{
+  graph: string;
+}>();
+
+const svg = ref('');
+const error = ref('');
+const source = ref('');
+const id = `mermaid-${Math.random().toString(36).slice(2)}`;
+
+mermaid.initialize({
+  securityLevel: 'loose',
+  startOnLoad: false,
+});
+
+async function renderDiagram() {
+  source.value = decodeURIComponent(props.graph);
+  error.value = '';
+
+  try {
+    const rendered = await mermaid.render(id, source.value);
+    svg.value = rendered.svg;
+  }
+  catch (err) {
+    svg.value = '';
+    error.value = err instanceof Error ? err.message : String(err);
+  }
+}
+
+onMounted(renderDiagram);
+watch(() => props.graph, renderDiagram);
+</script>
+
+<template>
+  <figure class="mermaid-diagram">
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <div v-if="svg" class="mermaid-diagram__svg" v-html="svg" />
+    <pre v-else class="mermaid-diagram__fallback"><code>{{ error || source }}</code></pre>
+  </figure>
+</template>

--- a/apps/docs/.vitepress/theme/custom.css
+++ b/apps/docs/.vitepress/theme/custom.css
@@ -14,3 +14,15 @@
 a {
   font-weight: 600;
 }
+/* Mermaid diagrams are rendered client-side from Markdown code fences. */
+.mermaid-diagram {
+  margin: 24px 0;
+}
+
+.mermaid-diagram__svg {
+  overflow-x: auto;
+}
+
+.mermaid-diagram__fallback {
+  white-space: pre-wrap;
+}

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -1,5 +1,12 @@
 import DefaultTheme from 'vitepress/theme';
 
+import MermaidDiagram from './MermaidDiagram.vue';
+
 import './custom.css';
 
-export default DefaultTheme;
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }) {
+    app.component('MermaidDiagram', MermaidDiagram);
+  },
+};

--- a/apps/docs/admin/foods/nutrient-data-model.md
+++ b/apps/docs/admin/foods/nutrient-data-model.md
@@ -1,0 +1,163 @@
+# How Intake24 stores and calculates nutrient data
+
+Intake24 keeps current food composition data and submitted survey data in different databases. The foods database is the current source. A submitted recall is a historical snapshot.
+
+This page explains the nutrient data model by following one pizza from food selection to a stored nutrient value.
+
+## The model in one minute
+
+A food selected in a recall does not contain nutrient values itself. Its locale and food code identify a locale food, which is mapped to a food composition record containing values per 100 g.
+
+Intake24 applies the consumed portion weight to those values. On submission, it stores the result as a snapshot so later changes to the foods database do not silently rewrite research data.
+
+```mermaid
+flowchart LR
+  A["Locale food<br/>UK_V3_2023 / CTTB"]
+  B["Food composition record<br/>UK_NDB_3_TEST / 10026"]
+  C["Value per 100 g<br/>260.0 kcal"]
+  D["Portion calculation<br/>260.0 x 184.25 / 100"]
+  E["Submitted snapshot<br/>479.05 kcal"]
+
+  A -->|food mapping| B
+  B --> C
+  C -->|apply consumed weight| D
+  D --> E
+```
+
+The first three steps use current source data. The final step is stored with the submitted recall.
+
+## Follow one pizza through Intake24
+
+### 1. Identify the locale food
+
+In locale `UK_V3_2023`, food code `CTTB` means **Cheese and tomato pizza**. A food code is unique within a locale, not across the whole Intake24 system.
+
+The pair `UK_V3_2023 / CTTB` is therefore the reliable identity used to find this food in the foods database.
+
+### 2. Select its food composition record
+
+The pizza's food mapping selects `UK_NDB_3_TEST / 10026`, named **CHEESE AND TOMATO PIZZA ANY BASE RETAIL**.
+
+This page calls it a **food composition record**. In the database schema, the same concept is a **nutrient table record**.
+
+The record supplies nutrient values per 100 g:
+
+| Nutrient type ID | Nutrient     | Unit | Value per 100 g |
+| ---------------- | ------------ | ---- | --------------: |
+| `1`              | Energy       | kcal |         `260.0` |
+| `2`              | Energy       | kJ   |        `1097.0` |
+| `11`             | Protein      | g    |          `11.3` |
+| `13`             | Carbohydrate | g    |          `36.0` |
+| `49`             | Fat          | g    |           `8.9` |
+
+Nutrient type IDs give variables a stable identity. For example, type `1` means Energy in kcal and determines both the unit and the key used in submitted nutrient JSON.
+
+### 3. Apply the consumed portion
+
+The composition record describes 100 g, but the participant consumed about `184.25 g`. Intake24 calculates each portion-level value with the same relationship:
+
+```text
+submitted nutrient value = value per 100 g * consumed weight / 100
+479.05 kcal = 260.0 kcal * 184.25 g / 100 g
+```
+
+The portion data can include serving and leftover weights. The resulting consumed weight is what scales the source values.
+
+### 4. Store the submitted snapshot
+
+When the recall is submitted, Intake24 stores nutrient type `1` with a portion-level value of about `479.05`. It does not store `260.0`, because that is the source value for 100 g.
+
+The submitted food also keeps its locale, food code and names, composition record reference, metadata fields, and portion data.
+
+:::: tip Developer note
+Submitted foods are rows in `survey_submission_foods`. Relevant columns include `locale`, `code`, `nutrient_table_id`, `nutrient_table_code`, `fields`, `nutrients`, and `portion_size`.
+::::
+
+## Current source data and submitted snapshots
+
+The foods database answers: **What food and composition data should Intake24 use now?**
+
+The system database answers: **What food, portion, and calculated nutrients were saved with this submission?**
+
+| Current foods database              | Submitted system database                      |
+| ----------------------------------- | ---------------------------------------------- |
+| Locale food name and code           | Saved locale, food code, and names             |
+| Current food-to-composition mapping | Saved composition table ID and record code     |
+| Current values per 100 g            | Saved nutrient values for the consumed portion |
+| Current composition metadata        | Saved `fields` JSON                            |
+| Used by current and future recalls  | Preserved as part of the submitted recall      |
+
+This separation explains why a submitted food can retain an old name, composition record, or nutrient value after an administrator changes the foods database.
+
+## How CSV import differs from food mapping
+
+Importing food composition data and mapping locale foods are separate jobs.
+
+1. **Import Nutrient data/ nutrient mapping** reads a source CSV (data) and its column configuration (mapping). It creates or updates composition records, metadata fields, and nutrient values per 100 g.
+2. **Food mapping** links a locale food such as `UK_V3_2023 / CTTB` to one of those imported composition records.
+
+Import therefore answers **what does this composition record contain?** Mapping answers **which composition record should this locale food use?**
+
+Importing a composition table does not, by itself, decide which locale food should use each record.
+
+:::: tip Developer note
+Composition import writes `nutrient_table_records`, `nutrient_table_record_fields`, and `nutrient_table_record_nutrients`. Food mapping writes the association in `foods_nutrients`.
+::::
+
+## What administrative changes affect
+
+| Administrative change                           | Current and future recalls                         | Already submitted recalls                                        |
+| ----------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------- |
+| Change a food name                              | Search and display use the new name                | Saved names remain unchanged                                     |
+| Correct a value per 100 g                       | New calculations use the corrected value           | Saved portion values remain unchanged until recalculation        |
+| Add or remove a nutrient or metadata field      | New calculations use the current record structure  | Saved JSON structure remains unchanged until a full sync         |
+| Remap a locale food to different nutrient table | New calculations use the latest composition record | Saved mapping remains unchanged unless recalculation replaces it |
+
+Changing source data never changes a submitted recall by itself.
+
+## Database table reference
+
+This reference connects the reader-facing concepts above to their implementation names.
+
+| Concept                 | Table or field                    | Purpose                                                             |
+| ----------------------- | --------------------------------- | ------------------------------------------------------------------- |
+| Locale food             | `foods`                           | Stores the food code and names within a locale                      |
+| Food mapping            | `foods_nutrients`                 | Associates a locale food with a composition record                  |
+| Composition table       | `nutrient_tables`                 | Groups composition records from one source                          |
+| Food composition record | `nutrient_table_records`          | Stores the source record ID and description                         |
+| Composition metadata    | `nutrient_table_record_fields`    | Stores extra values such as `sub_group_code`                        |
+| Values per 100 g        | `nutrient_table_record_nutrients` | Stores one value per nutrient type for a record                     |
+| Nutrient variable       | `nutrient_types`                  | Defines the nutrient identity and unit                              |
+| Nutrient unit           | `nutrient_units`                  | Defines symbols such as `kcal`, `kJ`, or `g`                        |
+| Submitted snapshot      | `survey_submission_foods`         | Stores the selected food, portion, fields, and calculated nutrients |
+
+:::: tip Developer note
+`survey_submission_foods.parent_id` is a self-link. It supports child rows such as recipe-builder components or split foods. Each child keeps its own identity, portion data, and nutrient snapshot.
+::::
+
+## Recalculation and per-food locales
+
+Submitted snapshots do not update automatically. The `SurveyNutrientsRecalculation` job can refresh their nutrient values and, when requested, replace the saved composition reference with the latest food mapping.
+
+Use `values-only` to preserve the original composition reference. Use `values-and-codes` only when submissions should follow the latest mapping.
+
+Set `syncFields: true` when the snapshot's nutrient and metadata keys should fully match the chosen composition record. Leave it `false` to update only values for keys already stored.
+
+The choice affects data provenance. See [SurveyNutrientsRecalculation job details](/admin/surveys/survey-nutrients-recalculation-job) for modes, structural syncing, edge cases, and operational safeguards.
+
+:::: warning Do not assume one locale per submission
+Every submitted food stores its own `locale`. Recalculation must resolve a food from that row's `locale + code`, because the same code can have different meanings or mappings in different locales.
+::::
+
+## Key terms
+
+| Term                        | Meaning                                                                         | Pizza example                       |
+| --------------------------- | ------------------------------------------------------------------------------- | ----------------------------------- |
+| Locale                      | The food database context in which a food code is unique                        | `UK_V3_2023`                        |
+| Food code                   | A stable identifier for a food within a locale                                  | `CTTB`                              |
+| Food composition record     | A source record containing metadata and nutrient values per 100 g               | `UK_NDB_3_TEST / 10026`             |
+| Nutrient type               | A stable nutrient variable with a defined unit                                  | `1` = Energy in kcal                |
+| Value per 100 g             | The source amount before portion weight is applied                              | `260.0 kcal`                        |
+| Consumed weight             | The portion amount after serving and leftovers are interpreted                  | about `184.25 g`                    |
+| Submitted nutrient snapshot | The calculated portion-level values saved with one submitted food               | type `1` = `479.05 kcal`            |
+| Recalculation               | An explicit job that refreshes submitted snapshots from source composition data | `values-only` or `values-and-codes` |

--- a/apps/docs/admin/surveys/index.md
+++ b/apps/docs/admin/surveys/index.md
@@ -248,14 +248,14 @@ Tasks section allows to submit resource specific tasks into the job queue with a
 
 Jobs that can be submitted:
 
-- [Authentication URLs export](/admin/system/job-types#surveyauthurlsexport)
+- [Authentication URLs export](/admin/surveys/tasks#surveyauthurlsexport)
 
-- [Nutrient recalculation](/admin/system/job-types#surveynutrientsrecalculation)
+- [Nutrient recalculation](/admin/surveys/survey-nutrients-recalculation-job)
 
-- [Ratings export](/admin/system/job-types#surveyratingsexport)
+- [Ratings export](/admin/surveys/tasks#surveyratingsexport)
 
-- [Respondents import](/admin/system/job-types#surveyrespondentsimport)
+- [Respondents import](/admin/surveys/tasks#surveyrespondentsimport)
 
-- [Submission data export](/admin/system/job-types#surveydataexport)
+- [Submission data export](/admin/surveys/tasks#surveydataexport)
 
-- [Sessions export](/admin/system/job-types#surveysessionsexport)
+- [Sessions export](/admin/surveys/tasks#surveysessionsexport)

--- a/apps/docs/admin/surveys/survey-nutrients-recalculation-job.md
+++ b/apps/docs/admin/surveys/survey-nutrients-recalculation-job.md
@@ -1,6 +1,46 @@
-## SurveyNutrientsRecalculation job details
+# Recalculating nutrients in submitted surveys
 
-### Database Fields Updated
+`SurveyNutrientsRecalculation` updates nutrient snapshots already stored with submitted recalls. It does not change locale foods, food mappings, or food composition records in the foods database.
+
+Read [How Intake24 stores and calculates nutrient data](/admin/foods/nutrient-data-model) first if the distinction between current source data and submitted snapshots is unfamiliar.
+
+## Choose what should remain historical
+
+The job separates two decisions:
+
+1. `mode` decides whether to preserve the submitted food composition reference or replace it with the latest food mapping.
+2. `syncFields` decides whether to preserve the submitted JSON keys or fully match the source record's current nutrients and fields.
+
+Food codes and saved food names never change. A mode that replaces the composition reference changes data provenance, so choose the intended historical boundary before running the job.
+
+## Per-food locale lookup
+
+Every `survey_submission_foods` row stores its own `locale`. A single survey can therefore contain submitted foods from more than one locale, including when a participant changes locale during a recall.
+
+When the job needs the current food mapping, it looks up each submitted food by its stored `locale + code`. It must not assume that every row uses the survey's current or configured locale.
+
+This matters because the same food code can have different names, composition mappings, fields, or nutrient values in different locales.
+
+:::: warning Check mixed-locale surveys before mutation
+Before running a mutating mode:
+
+1. Make each submitted food's locale visible in review tools or reports.
+2. Verify that each stored `locale + code` still identifies a food and, where required, a current composition mapping.
+3. Run `none` to verify the survey scope and processing counts without writing data.
+4. After the real run, inspect skipped-food warnings and download the error CSV when the job provides one.
+
+`none` follows the non-remapping path. It does not preview which composition references `values-and-codes` would replace.
+::::
+
+### Which modes use the submitted locale?
+
+- `values-and-codes` always uses `locale + code` to find the latest food mapping.
+- `syncFields: true` also checks the current locale food while synchronising structure, even with `values-only`.
+- `values-only` with `syncFields: false` can use the saved composition reference without finding the current locale food.
+
+If a required lookup cannot find the food in its submitted locale, the row is skipped and retained. The job records the reason in its summary and error CSV.
+
+## Database fields updated
 
 **Core submission data objects and properties affected** (depends on mode):
 
@@ -18,9 +58,9 @@
 - Nutrient values are stored as key-value pairs in `SurveySubmissionFood.nutrients` JSONB object (key: nutrient ID, value: amount)
 - Field values are stored as key-value pairs in `SurveySubmissionFood.fields` JSONB object (key: field ID, value: field value)
 
-### Detailed Mode Descriptions
+## Detailed mode descriptions
 
-#### `none`
+### `none`
 
 **No changes made.** This is a safety mode - the job completes without modifying any submission data.
 
@@ -43,7 +83,7 @@
 
 ---
 
-#### `values-only` (Default)
+### `values-only` (default)
 
 **Updates nutrient amounts using original nutrient codes.** Keeps the historical reference to nutrient composition data from submission time.
 
@@ -92,7 +132,7 @@ For each `SurveySubmissionFood`:
 
 ---
 
-#### `values-and-codes`
+### `values-and-codes`
 
 **Updates nutrient amounts using current food-to-nutrient mappings.** Changes the historical reference to use the current nutrient composition data.
 
@@ -147,7 +187,7 @@ For each `SurveySubmissionFood`:
 
 ---
 
-#### Edge Cases Handled
+### Edge cases handled
 
 The job processes these situations gracefully:
 
@@ -174,14 +214,14 @@ When individual nutrient variables are dropped from a record (but the record sti
 - **`syncFields: false`**: The nutrient key is preserved in the submission but its value is set to `0` (zeroed out). This preserves the submission structure while indicating the value is unresolvable.
 - **`syncFields: true`**: The nutrient key is fully removed from the submission, and any new nutrients in the source record are added.
 
-#### Performance Considerations
+### Performance considerations
 
 - Processes foods in batches of 100
 - Progress tracking updates incrementally
 - Job completion message includes statistics
 - Large surveys (10,000+ submissions) may take several minutes
 
-### Mode Combination Summary Table
+## Mode combination summary
 
 **Quick reference for all valid combinations:**
 
@@ -193,9 +233,9 @@ When individual nutrient variables are dropped from a record (but the record sti
 | **Remapped foods**       | `values-and-codes` | `false`    | → Changed         | → Values only  | Codes + existing nutrients/fields only      |
 | **Remapped + full sync** | `values-and-codes` | `true`     | → Changed         | → Full sync    | Codes + all nutrients + fields (add/remove) |
 
-### Use Case Examples
+## Use case examples
 
-#### Example 1: Nutrient Value Correction
+### Example 1: Nutrient value correction
 
 **Problem:** Vitamin C content for commonly-submitted foods was inaccurate in NDNS database. The values have now been corrected (e.g., Orange from 50mg→59mg per 100g).
 
@@ -246,7 +286,7 @@ SurveySubmissionFood {
 
 ---
 
-#### Example 2: New Nutrient Field Added
+### Example 2: New nutrient field added
 
 **Problem:** NDNS released new data with "Omega-3 fatty acids" for all foods. Existing submissions need this new nutrient field added.
 
@@ -304,9 +344,11 @@ SurveySubmissionFood {
 
 ---
 
-#### Example 3: Food Remapped to Better Nutrient Record
+### Example 3: Food remapped to better nutrient record
 
-**Problem:** Apple was originally mapped to generic "Apple" record (0100). NDNS has been updated with more accurate "Apple, Granny Smith" (0102). You want to update submissions to use the more accurate mapping and values, but you don't want to add new nutrients/fields that the new record might have—keep the existing structure.
+**Problem:** Apple was originally mapped to generic "Apple" record (0100). NDNS now has a more accurate "Apple, Granny Smith" record (0102).
+
+You want submissions to use the newer mapping and values while preserving their existing nutrient and field structure.
 
 **Survey context:**
 
@@ -373,7 +415,7 @@ SurveySubmissionFood {
 
 ---
 
-#### Example 4: Complete Food Database Update
+### Example 4: Complete food database update
 
 **Problem:** Nutrient mappings have been revised and nutrient tables restructured. Multiple fields were removed/added. Need complete nutrient synchronization.
 
@@ -441,7 +483,7 @@ SurveySubmissionFood {
 
 ---
 
-#### Example 5: Dry-Run / Testing Configuration
+### Example 5: Dry-run / testing configuration
 
 **Problem:** Want to test the job setup and parameter validation before running on live data.
 
@@ -468,13 +510,13 @@ SurveySubmissionFood {
 **Output example:**
 
 ```
-Started recalculation for survey 59 (mode: none)
-Processed: 2405 submissions
-Updated: 0, Skipped: 2405
-Result: No changes (mode=none)
+DRY RUN - NO DATA WAS MODIFIED. Recalculation completed.
+Total: 2405, Updated: 2405, Skipped: 0, Nutrient codes updated: 0
 ```
 
-### Job Output
+In a dry run, `Updated` counts rows for which the job produced recalculated values. It does not mean those values were written to the database.
+
+## Job output
 
 On completion, the job stores a summary message with statistics:
 

--- a/apps/docs/admin/surveys/tasks.md
+++ b/apps/docs/admin/surveys/tasks.md
@@ -90,7 +90,7 @@ Content-Type: application/json
 
 ## SurveyNutrientsRecalculation
 
-`SurveyNutrientsRecalculation` recalculates survey submission nutrient values with configurable modes for handling nutrient mapping references and field synchronization. This is useful when nutrient table data or food-to-nutrient mappings change.
+`SurveyNutrientsRecalculation` refreshes nutrient snapshots in submitted recalls. Its modes control whether to preserve stored composition references and whether to synchronise nutrient and field structure.
 
 ### Parameters
 
@@ -134,7 +134,7 @@ This table shows what gets updated in submission data for each mode and `syncFie
 Note: This task does not rename foods or replace missing submission food codes with new codes.
 ```
 
-Click [here](./survey-nutrients-recalculation-job) for detailed mode descriptions and use case examples.
+See [Recalculating nutrients in submitted surveys](./survey-nutrients-recalculation-job) for detailed mode descriptions, provenance warnings, mixed-locale safeguards, and use case examples.
 
 ## SurveyRatingsExport
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,6 +20,7 @@
     "@openapi-contrib/json-schema-to-openapi-schema": "^4.3.2",
     "@ts-rest/open-api": "3.53.0-rc.1",
     "@types/node": "^24.13.2",
+    "mermaid": "^11.14.0",
     "typescript": "^6.0.3",
     "unrun": "^0.3.1",
     "vitepress": "2.0.0-alpha.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -689,6 +689,9 @@ importers:
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
+      mermaid:
+        specifier: ^11.14.0
+        version: 11.15.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1933,6 +1936,9 @@ packages:
     resolution: {integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -1951,6 +1957,9 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       prom-client: '>= 10'
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@clack/core@1.4.1':
     resolution: {integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==}
@@ -3070,6 +3079,9 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
+
   '@microsoft/clarity@1.0.2':
     resolution: {integrity: sha512-9EZYROFpJxEGmQpHvUFqvD3ZJ7QQSqnibYSWmS+1xusoZfG1QQ1/Al9yVBBc11DWMbJrs1pe1hLT273it/skJg==}
 
@@ -3957,6 +3969,99 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -3983,6 +4088,9 @@ packages:
 
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -4276,6 +4384,9 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vite-pwa/assets-generator@1.0.2':
     resolution: {integrity: sha512-MCbrb508JZHqe7bUibmZj/lyojdhLRnfkmyXnkrCM2zVrjTgL89U8UEfInpKTvPeTnxsw2hmyZxnhsdNR6yhwg==}
@@ -5089,6 +5200,10 @@ packages:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -5241,6 +5356,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cosmiconfig@9.0.2:
     resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
     engines: {node: '>=14'}
@@ -5326,6 +5447,162 @@ packages:
 
   cwise-compiler@1.1.3:
     resolution: {integrity: sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -5437,6 +5714,9 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -6314,6 +6594,9 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
@@ -6428,6 +6711,10 @@ packages:
   ico-endec@0.1.6:
     resolution: {integrity: sha512-ZdLU38ZoED3g1j3iEyzcQj+wAkY2xfWNkymszfJPoxucIUhK7NayQ+/C4Kv0nDFMIsbtbEHldv3V8PU494/ueQ==}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -6491,6 +6778,13 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
@@ -6907,6 +7201,9 @@ packages:
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -6962,6 +7259,12 @@ packages:
 
   launder@1.7.1:
     resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -7167,6 +7470,11 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -7252,6 +7560,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -7794,6 +8105,9 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -7954,6 +8268,12 @@ packages:
 
   pnpm-workspace-yaml@1.6.1:
     resolution: {integrity: sha512-yTeZntGWi8m9WNuhoVsP0DpFc4sC1U0+rr/qR6Zi9n2g3sxXY+JfccjXjjruNz96tM8I09yaJUA86doRnNLkbg==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -8258,6 +8578,9 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown-plugin-dts@0.25.2:
     resolution: {integrity: sha512-nMhN/R+vmR8GM45ZW1FWMSjRTSDDn/6w4GTf8RNrEFCBdl8B1kySWrU1ixPtbwzXoRlcO+R/S88VgXuJQwfdDg==}
     engines: {node: ^22.18.0 || >=24.0.0}
@@ -8287,6 +8610,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -8297,6 +8623,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -8707,6 +9036,9 @@ packages:
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
     engines: {node: '>=14.18.0'}
@@ -8902,6 +9234,10 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
+
   ts-deepmerge@6.2.1:
     resolution: {integrity: sha512-8CYSLazCyj0DJDpPIxOFzJG46r93uh6EynYjuey+bxcLltBeqZL7DMfaE5ZPzZNFlav7wx+2TDa/mBl8gkTYzw==}
     engines: {node: '>=14.13.1'}
@@ -8917,6 +9253,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -10692,6 +11029,8 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0-rc.6
       '@babel/helper-validator-identifier': 8.0.0-rc.6
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -10713,6 +11052,8 @@ snapshots:
   '@chainsafe/prometheus-gc-stats@1.0.2(prom-client@15.1.3)':
     dependencies:
       prom-client: 15.1.3
+
+  '@chevrotain/types@11.1.2': {}
 
   '@clack/core@1.4.1':
     dependencies:
@@ -11605,6 +11946,10 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
+
   '@microsoft/clarity@1.0.2': {}
 
   '@mongodb-js/saslprep@1.4.11':
@@ -12343,6 +12688,123 @@ snapshots:
     dependencies:
       '@types/node': 24.13.2
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -12378,6 +12840,8 @@ snapshots:
     dependencies:
       '@types/jsonfile': 6.1.4
       '@types/node': 24.13.2
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -12709,6 +13173,11 @@ snapshots:
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260611.2
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vite-pwa/assets-generator@1.0.2':
     dependencies:
@@ -13573,6 +14042,8 @@ snapshots:
 
   commander@5.1.0: {}
 
+  commander@7.2.0: {}
+
   commander@8.3.0: {}
 
   comment-parser@1.4.5: {}
@@ -13711,6 +14182,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   cosmiconfig@9.0.2(typescript@6.0.3):
     dependencies:
       env-paths: 2.2.1
@@ -13794,6 +14273,190 @@ snapshots:
     dependencies:
       uniq: 1.0.1
     optional: true
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
 
   data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
@@ -13919,6 +14582,10 @@ snapshots:
       object-keys: 1.1.1
 
   defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -14999,6 +15666,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  hachure-fill@0.5.2: {}
+
   handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
@@ -15133,6 +15802,10 @@ snapshots:
 
   ico-endec@0.1.6: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -15180,6 +15853,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ioredis@5.10.1:
     dependencies:
@@ -15591,6 +16268,8 @@ snapshots:
     dependencies:
       '@keyv/serialize': 1.1.1
 
+  khroma@2.1.0: {}
+
   kleur@3.0.3: {}
 
   kolorist@1.8.0: {}
@@ -15621,6 +16300,10 @@ snapshots:
   launder@1.7.1:
     dependencies:
       dayjs: 1.11.21
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lazystream@1.0.1:
     dependencies:
@@ -15807,6 +16490,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked@16.4.2: {}
+
   math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
@@ -15969,6 +16654,30 @@ snapshots:
       is-plain-obj: 2.1.0
 
   merge2@1.4.1: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.9
+      es-toolkit: 1.46.1
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.0
 
   methods@1.1.2: {}
 
@@ -16658,6 +17367,8 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-data-parser@0.1.0: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -16785,6 +17496,13 @@ snapshots:
   pnpm-workspace-yaml@1.6.1:
     dependencies:
       yaml: 2.9.0
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -17090,6 +17808,8 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
+  robust-predicates@3.0.3: {}
+
   rolldown-plugin-dts@0.25.2(@typescript/native-preview@7.0.0-dev.20260611.2)(rolldown@1.1.1)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.6
@@ -17159,6 +17879,13 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -17174,6 +17901,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -17679,6 +18408,8 @@ snapshots:
 
   style-mod@4.1.3: {}
 
+  stylis@4.4.0: {}
+
   superagent@10.3.0:
     dependencies:
       component-emitter: 1.3.1
@@ -17892,6 +18623,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  ts-dedent@2.3.0: {}
 
   ts-deepmerge@6.2.1: {}
 


### PR DESCRIPTION
## Summary

Improve the safety and observability of survey nutrient recalculation, particularly for mixed-locale surveys and foods whose current mappings differ from their submitted food composition table (FCT).

## Changes

- Log missing `locale + food code` mappings with actionable context.
- Generate a downloadable CSV for foods skipped because they are unavailable in their submitted locale.
- Include skipped-food guidance in the completed job summary.
- Document recalculation modes, historical-data boundaries, mixed-locale behavior, and error handling.
- Add a nutrient data model guide with diagram support.
- Add integration coverage for cross-FCT recalculation scenarios.

## Testing

Added integration tests covering cross-FCT behavior for:

- `values-only` with and without `syncFields`
- `values-and-codes` with and without `syncFields`
- preservation or replacement of stored FCT references
- addition, removal, and zeroing of nutrient values