### PR TITLE
Enhance gtm events to track prompt changes 

### DIFF
--- a/apps/survey/src/components/elements/CategoryContentsView.vue
+++ b/apps/survey/src/components/elements/CategoryContentsView.vue
@@ -215,7 +215,6 @@ function categorySelected(category: CategoryHeader) {
   emit('categorySelected', category);
   sendGtmEvent({
     event: 'selectFoodCategory',
-    scheme_prompts: 'foods',
     food_category: category.name,
     search_term: props.searchTerm,
     search_count: props.searchCount,
@@ -227,7 +226,6 @@ function foodSelected(food: FoodHeader) {
   emit('foodSelected', food);
   sendGtmEvent({
     event: 'selectFood',
-    scheme_prompts: 'foods',
     food: food.name,
     search_term: props.searchTerm,
     search_count: props.searchCount,

--- a/apps/survey/src/components/elements/FoodBrowser.vue
+++ b/apps/survey/src/components/elements/FoodBrowser.vue
@@ -449,7 +449,6 @@ async function search() {
       );
       sendGtmEvent({
         event: 'foodSearch',
-        scheme_prompts: 'foods',
         search_term: searchTerm.value,
         search_term_order: searchCount.value,
         search_results_count: searchResults.value.foods.length,

--- a/apps/survey/src/components/recall/use-recall.ts
+++ b/apps/survey/src/components/recall/use-recall.ts
@@ -24,6 +24,7 @@ import {
   maybePushFallbackHistoryEntry,
   pushFullHistoryEntry,
 } from '@intake24/survey/stores/recall-history';
+import { recordPromptTransition } from '@intake24/survey/util';
 import { useI18n } from '@intake24/ui/i18n';
 
 export function useRecall() {
@@ -37,6 +38,11 @@ export function useRecall() {
   const currentPrompt = ref<PromptInstance | null>(null);
   const recallController = shallowRef<DynamicRecall | null>(null);
   const hideCurrentPrompt = ref(false);
+  const {
+    clearPromptTransition,
+    setCurrentPrompt,
+    setPromptTransitionAction,
+  } = createPromptTransitionController();
 
   const {
     hasFinished,
@@ -102,7 +108,8 @@ export function useRecall() {
 
     if (result === 'full') {
       hideCurrentPrompt.value = true;
-      currentPrompt.value = recallController.value?.getNextPrompt() ?? null;
+      setPromptTransitionAction('popstate');
+      setCurrentPrompt(recallController.value?.getNextPrompt() ?? null);
       hideCurrentPrompt.value = false;
     }
   };
@@ -112,7 +119,7 @@ export function useRecall() {
       return;
 
     // Prevent the currently active prompt from crashing if it expects a different selection type
-    currentPrompt.value = null;
+    setCurrentPrompt(null);
     survey.setSelection(newSelection);
   };
 
@@ -131,7 +138,7 @@ export function useRecall() {
       );
     }
 
-    currentPrompt.value = { section: promptSection, prompt };
+    setCurrentPrompt({ section: promptSection, prompt });
   };
 
   function showFoodPrompt(foodId: string, promptSection: MealSection, promptType: ComponentType) {
@@ -142,7 +149,7 @@ export function useRecall() {
     if (!prompt)
       throw new Error(`Survey scheme is missing required food prompt of type ${promptType}`);
 
-    currentPrompt.value = { section: promptSection, prompt };
+    setCurrentPrompt({ section: promptSection, prompt });
   };
 
   function showSurveyPrompt(promptSection: SurveyPromptSection, promptType: ComponentType) {
@@ -159,10 +166,12 @@ export function useRecall() {
       );
     }
 
-    currentPrompt.value = { section: promptSection, prompt };
+    setCurrentPrompt({ section: promptSection, prompt });
   };
 
   async function action(type: string, id?: string, params?: object) {
+    setPromptTransitionAction(type);
+
     switch (type) {
       case 'next':
         await next();
@@ -287,10 +296,10 @@ export function useRecall() {
       if (hasMeals.value)
         await recallAction('addMeal');
       else
-        currentPrompt.value = null;
+        setCurrentPrompt(null);
     }
     else {
-      currentPrompt.value = nextPrompt;
+      setCurrentPrompt(nextPrompt);
       createFallbackHistoryEntry(nextPrompt.prompt.component);
     }
   };
@@ -316,7 +325,7 @@ export function useRecall() {
   };
 
   async function restart() {
-    currentPrompt.value = null;
+    setCurrentPrompt(null);
     await survey.cancelRecall();
     await router.push({
       name: 'survey-home',
@@ -341,13 +350,48 @@ export function useRecall() {
 
   onMounted(async () => {
     addEventListener('popstate', onPopState);
+    setPromptTransitionAction('loadRecallUI');
     await nextPrompt();
   });
 
   onBeforeUnmount(() => {
     removeEventListener('popstate', onPopState);
+    clearPromptTransition();
     destroyRecallHistory();
   });
+
+  function createPromptTransitionController() {
+    let promptTransitionAction = 'not mapped';
+
+    function setPromptTransitionAction(action: string) {
+      promptTransitionAction = action;
+    }
+
+    function setCurrentPrompt(promptInstance: PromptInstance | null) {
+      currentPrompt.value = promptInstance;
+
+      if (!promptInstance)
+        return;
+
+      recordPromptTransition({
+        action: promptTransitionAction,
+        prompt_id: promptInstance.prompt.id,
+        section: promptInstance.section,
+        prompt_component: promptInstance.prompt.component,
+      });
+    }
+
+    function clearPromptTransition() {
+      promptTransitionAction = 'not mapped';
+      recordPromptTransition(null);
+    }
+
+    return {
+      clearPromptTransition,
+      setCurrentPrompt,
+      setPromptTransitionAction,
+    };
+  }
 
   return {
     currentPrompt,

--- a/apps/survey/src/composables/use-prompt-utils.ts
+++ b/apps/survey/src/composables/use-prompt-utils.ts
@@ -114,7 +114,6 @@ export function usePromptUtils<
       const gtmEventParams: GtmEventParams = {
         event: type as GtmEventParams['event'],
         action: type,
-        prompt_id: props.prompt.id,
         meal: mealName.value,
         food: foodName.value,
       };

--- a/apps/survey/src/stores/survey.ts
+++ b/apps/survey/src/stores/survey.ts
@@ -296,7 +296,7 @@ export const useSurvey = defineStore('survey', {
       sendGtmEvent({
         event: 'startRecall',
         action: 'start',
-        scheme_prompts: 'preMeals',
+        section: 'preMeals',
       });
 
       await this.startUserSession();
@@ -307,7 +307,7 @@ export const useSurvey = defineStore('survey', {
       sendGtmEvent({
         event: 'cancelRecall',
         action: 'cancel',
-        scheme_prompts: 'preMeals',
+        section: 'preMeals',
       });
       this.clearState();
       await this.clearUserSession(uxSessionId);
@@ -439,7 +439,7 @@ export const useSurvey = defineStore('survey', {
         this.data.submissionTime = submission.submissionTime;
         sendGtmEvent({
           event: 'recallSubmitted',
-          scheme_prompts: 'submission',
+          section: 'submission',
         });
 
         clearPromptStores();

--- a/apps/survey/src/util/gtmEvent.spec.ts
+++ b/apps/survey/src/util/gtmEvent.spec.ts
@@ -1,0 +1,322 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const trackEvent = vi.fn();
+const survey = {
+  data: { uxSessionId: 'ux-session-id' },
+  user: { userId: 'ux-user-id' },
+  selectedMealOptional: undefined as { name: Record<string, string> } | undefined,
+};
+
+vi.mock('@gtm-support/vue-gtm', () => ({
+  useGtm: () => ({ trackEvent }),
+}));
+
+vi.mock('@intake24/survey/stores', () => ({
+  useSurvey: () => survey,
+}));
+
+describe('sendGtmEvent', async () => {
+  const gtmEvent = await import('./gtmEvent');
+
+  beforeEach(() => {
+    trackEvent.mockClear();
+    survey.selectedMealOptional = undefined;
+    gtmEvent.recordPromptTransition(null);
+    window.dataLayer = [];
+  });
+
+  it('sets prompt_id to not mapped when no prompt is supplied', () => {
+    gtmEvent.sendGtmEvent({
+      event: 'surveyLogout',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'surveyLogout',
+      noninteraction: false,
+      prompt_id: 'not mapped',
+      uxSessionId: 'ux-session-id',
+      uxUserId: 'ux-user-id',
+    }));
+  });
+
+  it('sets prompt_id to not mapped when prompt is empty', () => {
+    gtmEvent.sendGtmEvent({
+      event: 'foodSearch',
+      prompt_id: '',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'foodSearch',
+      noninteraction: false,
+      prompt_id: 'not mapped',
+      uxSessionId: 'ux-session-id',
+      uxUserId: 'ux-user-id',
+    }));
+  });
+
+  it('preserves mapped prompt ids', () => {
+    gtmEvent.sendGtmEvent({
+      event: 'foodSearch',
+      prompt_id: 'food-search-prompt',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'foodSearch',
+      noninteraction: false,
+      prompt_id: 'food-search-prompt',
+      uxSessionId: 'ux-session-id',
+      uxUserId: 'ux-user-id',
+    }));
+  });
+
+  it('uses current prompt context when prompt is not supplied on the event', () => {
+    gtmEvent.recordPromptTransition({
+      prompt_id: 'meal-time-prompt',
+      section: 'preFoods',
+      prompt_component: 'meal-time-prompt',
+    });
+
+    gtmEvent.sendGtmEvent({
+      event: 'surveyLogout',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'surveyLogout',
+      noninteraction: false,
+      prompt_component: 'meal-time-prompt',
+      prompt_id: 'meal-time-prompt',
+      section: 'preFoods',
+      uxSessionId: 'ux-session-id',
+      uxUserId: 'ux-user-id',
+    }));
+  });
+
+  it('keeps explicit event prompt id when current prompt context is set', () => {
+    gtmEvent.recordPromptTransition({
+      prompt_id: 'meal-time-prompt',
+      section: 'preFoods',
+      prompt_component: 'meal-time-prompt',
+    });
+
+    gtmEvent.sendGtmEvent({
+      event: 'foodSearch',
+      prompt_id: 'food-search-prompt',
+      section: 'foods',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'foodSearch',
+      noninteraction: false,
+      prompt_component: 'meal-time-prompt',
+      prompt_id: 'food-search-prompt',
+      section: 'foods',
+      uxSessionId: 'ux-session-id',
+      uxUserId: 'ux-user-id',
+    }));
+  });
+
+  it('pushes prompt context to dataLayer for GTM automatic events', () => {
+    gtmEvent.recordPromptTransition({
+      prompt_id: 'meal-add-prompt',
+      section: 'preMeals',
+      prompt_component: 'meal-add-prompt',
+    });
+    window.dataLayer = [];
+
+    gtmEvent.recordPromptTransition({
+      action: 'editMeal',
+      prompt_id: 'edit-meal-prompt',
+      section: 'preFoods',
+      prompt_component: 'edit-meal-prompt',
+    });
+
+    expect(window.dataLayer).toContainEqual(expect.objectContaining(
+      {
+        action: 'editMeal',
+        event: 'promptChanged',
+        noninteraction: false,
+        prompt_component: 'edit-meal-prompt',
+        prompt_id: 'edit-meal-prompt',
+        previous_prompt_component: 'meal-add-prompt',
+        previous_prompt_id: 'meal-add-prompt',
+        previous_section: 'preMeals',
+        section: 'preFoods',
+        uxSessionId: 'ux-session-id',
+        uxUserId: 'ux-user-id',
+      },
+    ));
+  });
+
+  it('clears event-scoped fields on prompt context events', () => {
+    gtmEvent.recordPromptTransition({
+      action: 'next',
+      prompt_id: 'drink-scale-prompt',
+      section: 'foods',
+      prompt_component: 'drink-scale-prompt',
+    });
+
+    expect(window.dataLayer).toContainEqual(expect.objectContaining({
+      event: 'promptChanged',
+      faq_question_title: null,
+      faq_section_title: null,
+      food: null,
+      food_category: null,
+      label: null,
+      meal: null,
+      percent_scrolled: null,
+      search_count: null,
+      search_results_count: null,
+      search_term: null,
+      search_term_order: null,
+      target: null,
+      'content-name': null,
+      'content-view-name': null,
+      'interaction-type': null,
+      'target-properties': null,
+      value: null,
+    }));
+  });
+
+  it('clears stale event-scoped fields before applying custom event fields', () => {
+    gtmEvent.sendGtmEvent({
+      event: 'foodSearch',
+      search_term: 'juice',
+      search_count: 1,
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'foodSearch',
+      faq_question_title: null,
+      faq_section_title: null,
+      food: null,
+      food_category: null,
+      label: null,
+      meal: null,
+      percent_scrolled: null,
+      search_count: 1,
+      search_results_count: null,
+      search_term: 'juice',
+      search_term_order: null,
+    }));
+  });
+
+  it('uses the selected meal when an event does not provide one', () => {
+    survey.selectedMealOptional = {
+      name: { en: 'Breakfast' },
+    };
+
+    gtmEvent.sendGtmEvent({
+      event: 'selectFood',
+      food: 'Apple juice',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'selectFood',
+      food: 'Apple juice',
+      meal: 'Breakfast',
+    }));
+  });
+
+  it('keeps explicit event meal when selected meal is available', () => {
+    survey.selectedMealOptional = {
+      name: { en: 'Breakfast' },
+    };
+
+    gtmEvent.sendGtmEvent({
+      event: 'deleteMeal',
+      meal: 'Lunch',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'deleteMeal',
+      meal: 'Lunch',
+    }));
+  });
+
+  it('adds previous prompt context to custom events', () => {
+    gtmEvent.recordPromptTransition({
+      prompt_id: 'edit-meal-prompt',
+      section: 'preFoods',
+      prompt_component: 'edit-meal-prompt',
+    });
+
+    gtmEvent.recordPromptTransition({
+      action: 'next',
+      prompt_id: 'meal-time-prompt',
+      section: 'preFoods',
+      prompt_component: 'meal-time-prompt',
+    });
+
+    gtmEvent.sendGtmEvent({
+      event: 'surveyLogout',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'surveyLogout',
+      noninteraction: false,
+      action: 'next',
+      previous_prompt_component: 'edit-meal-prompt',
+      previous_prompt_id: 'edit-meal-prompt',
+      previous_section: 'preFoods',
+      prompt_component: 'meal-time-prompt',
+      prompt_id: 'meal-time-prompt',
+      section: 'preFoods',
+      uxSessionId: 'ux-session-id',
+      uxUserId: 'ux-user-id',
+    }));
+  });
+
+  it('keeps explicit event action when current prompt context has prompt change action', () => {
+    gtmEvent.recordPromptTransition({
+      action: 'next',
+      prompt_id: 'meal-time-prompt',
+      section: 'preFoods',
+      prompt_component: 'meal-time-prompt',
+    });
+
+    gtmEvent.sendGtmEvent({
+      event: 'deleteMeal',
+      action: 'deleteMeal',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'deleteMeal',
+      action: 'deleteMeal',
+      noninteraction: false,
+      prompt_component: 'meal-time-prompt',
+      prompt_id: 'meal-time-prompt',
+      section: 'preFoods',
+      uxSessionId: 'ux-session-id',
+      uxUserId: 'ux-user-id',
+    }));
+  });
+
+  it('clears prompt context when transition is reset', () => {
+    gtmEvent.recordPromptTransition({
+      prompt_id: 'edit-meal-prompt',
+      section: 'preFoods',
+      prompt_component: 'edit-meal-prompt',
+    });
+    gtmEvent.recordPromptTransition({
+      action: 'next',
+      prompt_id: 'meal-time-prompt',
+      section: 'preFoods',
+      prompt_component: 'meal-time-prompt',
+    });
+
+    gtmEvent.recordPromptTransition(null);
+    trackEvent.mockClear();
+
+    gtmEvent.sendGtmEvent({
+      event: 'surveyLogout',
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'surveyLogout',
+      noninteraction: false,
+      prompt_id: 'not mapped',
+      uxSessionId: 'ux-session-id',
+      uxUserId: 'ux-user-id',
+    }));
+  });
+});

--- a/apps/survey/src/util/gtmEvent.ts
+++ b/apps/survey/src/util/gtmEvent.ts
@@ -4,15 +4,130 @@ import { useGtm } from '@gtm-support/vue-gtm';
 
 import { useSurvey } from '@intake24/survey/stores';
 
+export const GTM_PROMPT_ID_NOT_MAPPED = 'not mapped';
+export const GTM_PROMPT_CONTEXT_EVENT = 'promptChanged';
+
+export type PromptTransition = Pick<GtmEventParams, 'action' | 'prompt_id' | 'section'> & {
+  prompt_component?: string;
+};
+
+type GtmPromptTrackingParams = PromptTransition & {
+  previous_prompt_id?: string;
+  previous_section?: string;
+  previous_prompt_component?: string;
+};
+
+type GtmPayload = Omit<GtmEventParams, 'event'> & {
+  event?: GtmEventParams['event'] | typeof GTM_PROMPT_CONTEXT_EVENT;
+};
+
+type PromptContext = {
+  current: PromptTransition | null;
+  previous: PromptTransition | null;
+};
+
+const promptContext: PromptContext = {
+  current: null,
+  previous: null,
+};
+
+const eventFieldNames = [
+  'meal',
+  'food',
+  'food_category',
+  'label',
+  'search_term',
+  'search_count',
+  'percent_scrolled',
+  'search_term_order',
+  'search_results_count',
+  'faq_section_title',
+  'faq_question_title',
+  'target',
+  'target-properties',
+  'value',
+  'interaction-type',
+  'content-name',
+  'content-view-name',
+] as const;
+
+const clearedEventFields = Object.fromEntries(eventFieldNames.map(field => [field, null]));
+
+function mealName() {
+  const name = useSurvey().selectedMealOptional?.name;
+
+  return name ? name.en ?? Object.values(name)[0] : undefined;
+}
+
+function currentFields(prompt: PromptTransition | null): GtmPromptTrackingParams {
+  return {
+    prompt_id: prompt?.prompt_id ?? GTM_PROMPT_ID_NOT_MAPPED,
+    ...(prompt?.section && { section: prompt.section }),
+    ...(prompt?.prompt_component && { prompt_component: prompt.prompt_component }),
+    ...(prompt?.action && { action: prompt.action }),
+  };
+}
+
+function previousFields(prompt: PromptTransition | null): Partial<GtmPromptTrackingParams> {
+  return {
+    ...(prompt?.prompt_id && { previous_prompt_id: prompt.prompt_id }),
+    ...(prompt?.section && { previous_section: prompt.section }),
+    ...(prompt?.prompt_component && { previous_prompt_component: prompt.prompt_component }),
+  };
+}
+
+function promptFields(context: PromptContext): GtmPromptTrackingParams {
+  return {
+    ...currentFields(context.current),
+    ...previousFields(context.previous),
+  };
+}
+
+function defaultFields() {
+  const survey = useSurvey();
+
+  return {
+    uxSessionId: survey.data.uxSessionId,
+    uxUserId: survey.user?.userId || '',
+    noninteraction: false,
+  };
+}
+
+function buildEvent(params: GtmPayload) {
+  const context = promptFields(promptContext);
+  const meal = mealName();
+
+  return {
+    ...clearedEventFields,
+    ...defaultFields(),
+    ...(meal && { meal }),
+    ...context,
+    ...params,
+    prompt_id: params.prompt_id || context.prompt_id,
+  };
+}
+
+export function recordPromptTransition(transition: PromptTransition | null): void {
+  if (transition) {
+    promptContext.previous = promptContext.current;
+    promptContext.current = {
+      ...transition,
+      prompt_id: transition.prompt_id || GTM_PROMPT_ID_NOT_MAPPED,
+    };
+  }
+  else {
+    promptContext.current = null;
+    promptContext.previous = null;
+  }
+
+  window.dataLayer?.push(buildEvent({
+    event: GTM_PROMPT_CONTEXT_EVENT,
+  }));
+}
+
 export function sendGtmEvent(params: GtmEventParams): void {
   try {
-    const survey = useSurvey();
-    const defaults = {
-      uxSessionId: survey.data.uxSessionId,
-      uxUserId: survey.user?.userId || '',
-      noninteraction: false,
-    };
-    useGtm()?.trackEvent({ ...defaults, ...params });
+    useGtm()?.trackEvent(buildEvent(params));
   }
   catch (e) {
     console.error('Error sending GTM event:', e);

--- a/apps/survey/src/views/survey/home.vue
+++ b/apps/survey/src/views/survey/home.vue
@@ -367,7 +367,7 @@ export default defineComponent({
       sendGtmEvent({
         event: 'surveyHome',
         action: 'login',
-        scheme_prompts: 'preMeals',
+        section: 'preMeals',
       });
       submissions.value = await userService.submissions(props.surveyId);
     });

--- a/apps/survey/src/views/survey/login.vue
+++ b/apps/survey/src/views/survey/login.vue
@@ -149,7 +149,7 @@ async function submit() {
 onMounted(async () => {
   sendGtmEvent({
     event: 'surveyLogin',
-    scheme_prompts: 'preMeals',
+    section: 'preMeals',
   });
   await fetchSurveyPublicInfo();
   if (!survey.value) {

--- a/packages/ui/src/tracking/index.ts
+++ b/packages/ui/src/tracking/index.ts
@@ -16,8 +16,8 @@ export const gtmEvents = [
 ] as const;
 type GtmEvent = (typeof gtmEvents)[number];
 
-// Event category for Google Analytics, deduced from Scheme prompts structure, or section of Prompts
-export const gtmSchemePrompts = [
+// Event category for Google Analytics, deduced from the prompt section.
+export const gtmSections = [
   'preMeals',
   'postMeals',
   'submission',
@@ -26,11 +26,11 @@ export const gtmSchemePrompts = [
   'postFoods',
   'foodsDeferred',
 ] as const;
-export type GtmSchemePrompt = typeof gtmSchemePrompts[number];
+export type GtmSection = typeof gtmSections[number];
 
 export type GtmEventParams = {
   event?: GtmEvent; // event type, e.g. GtmEvents.DeleteMeal, which is 'deleteMeal'. Open to new event types
-  scheme_prompts?: GtmSchemePrompt | string;
+  section?: GtmSection | string;
   meal?: string;
   food?: string; // food name, e.g. "Fresh fruit salad"
   food_category?: string; // food category, e.g. "Ham / gammon"


### PR DESCRIPTION
## Summary

This PR improves GTM prompt tracking in the survey app by centralising prompt context in `gtmEvent.ts`.

It adds a `promptChanged` data-layer event whenever the active recall prompt changes, and includes current and previous prompt context on GTM custom events where available:

- `prompt_id`
- `prompt_component`
- `section`
- `previous_prompt_id`
- `previous_prompt_component`
- `previous_section`
- `action`

It also renames the analytics field from `scheme_prompts` to `section`, which better reflects the actual value being tracked.

## Why

Some custom GTM events did not include a useful `prompt_id`, making it difficult to map GA/GTM events back to the prompt the user was viewing. Prompt context is now tracked centrally, so standalone events can inherit the active prompt context without passing prompt IDs through component props manually.

## Validation

- `pnpm --filter @intake24/survey exec vitest run src/util/gtmEvent.spec.ts`
- `pnpm --filter @intake24/survey type-check`