### PR TITLE
fix(food-index-ranking): normalize sorting algorithm naming

### DIFF
--- a/apps/api/src/food-index/ranking/ranking.ts
+++ b/apps/api/src/food-index/ranking/ranking.ts
@@ -7,8 +7,6 @@ import { getFixedRanking } from '@intake24/api/food-index/ranking/fixed-ranking'
 import { getGlobalPopularityRanking } from '@intake24/api/food-index/ranking/global-popularity';
 import { getLocalPopularityRanking } from '@intake24/api/food-index/ranking/local-popularity';
 
-export type RankingAlgorithm = '';
-
 export type RankingData = {
   [foodCode: string]: number;
 };

--- a/apps/api/src/food-index/search-query.ts
+++ b/apps/api/src/food-index/search-query.ts
@@ -5,7 +5,7 @@ import { defaultSearchSettings } from '@intake24/common/surveys';
 export interface OptionalSearchQueryParameters {
   previous?: string[];
   limit?: number;
-  rankingAlgorithm?: SearchSortingAlgorithm;
+  sortingAlgorithm?: SearchSortingAlgorithm;
   matchScoreWeight?: number;
   includeHidden?: boolean;
   limitToCategory?: string;
@@ -28,7 +28,7 @@ export interface SearchQueryParameters {
   description: string;
   previous: string[];
   limit: number;
-  rankingAlgorithm: SearchSortingAlgorithm;
+  sortingAlgorithm: SearchSortingAlgorithm;
   matchScoreWeight: number;
   includeHidden: boolean;
   limitToCategory?: string;
@@ -58,7 +58,7 @@ export function applyDefaultSearchQueryParameters(localeId: string, description:
     description,
     previous: optionalParameters.previous ?? [],
     limit: optionalParameters.limit ?? defaultSearchSettings.maxResults,
-    rankingAlgorithm: optionalParameters.rankingAlgorithm ?? defaultSearchSettings.sortingAlgorithm,
+    sortingAlgorithm: optionalParameters.sortingAlgorithm ?? defaultSearchSettings.sortingAlgorithm,
     matchScoreWeight: optionalParameters.matchScoreWeight ?? defaultSearchSettings.matchScoreWeight,
     includeHidden: optionalParameters.includeHidden ?? false,
     limitToCategory: optionalParameters.limitToCategory ?? optionalParameters.limitToCategory,

--- a/apps/api/src/food-index/workers/index-builder.ts
+++ b/apps/api/src/food-index/workers/index-builder.ts
@@ -288,7 +288,7 @@ async function queryIndex(query: SearchQuery): Promise<FoodSearchResponse> {
   const foods = await rankFoodResults(
     foodResults,
     query.parameters.localeId,
-    query.parameters.rankingAlgorithm,
+    query.parameters.sortingAlgorithm,
     query.parameters.matchScoreWeight / 100.0,
     logger,
     foodBuilderHeaders,

--- a/apps/api/src/http/routers/food.router.ts
+++ b/apps/api/src/http/routers/food.router.ts
@@ -36,14 +36,14 @@ export function food() {
       return { status: 200, body: codes };
     },
     search: async ({ params, query, req }) => {
-      const { description, matchScoreWeight, rankingAlgorithm, hidden, category: limitToCategory, limit, previous, recipe } = query;
+      const { description, matchScoreWeight, sortingAlgorithm, hidden, category: limitToCategory, limit, previous, recipe } = query;
       const { localeId } = params;
 
       const searchOptions: OptionalSearchQueryParameters = {
         previous,
         limit,
         includeHidden: hidden === 'true',
-        rankingAlgorithm,
+        sortingAlgorithm,
         matchScoreWeight,
         limitToCategory,
       };

--- a/apps/survey/src/stores/survey.ts
+++ b/apps/survey/src/stores/survey.ts
@@ -145,10 +145,10 @@ export const useSurvey = defineStore('survey', {
     meals: state => state.data.meals,
     parametersLoaded: state => !!state.parameters && !!state.user,
     searchParameters: (state) => {
-      const { searchSortingAlgorithm: rankingAlgorithm, searchMatchScoreWeight: matchScoreWeight }
+      const { searchSortingAlgorithm: sortingAlgorithm, searchMatchScoreWeight: matchScoreWeight }
         = state.parameters ?? {};
 
-      return { matchScoreWeight, rankingAlgorithm };
+      return { matchScoreWeight, sortingAlgorithm };
     },
     surveyEnabled: state => state.parameters?.state === 'active',
     dailyLimitReached: state => !!state.user?.maximumDailySubmissionsReached,

--- a/packages/common/src/types/http/foods/search.ts
+++ b/packages/common/src/types/http/foods/search.ts
@@ -49,7 +49,7 @@ export const foodSearchQuery = z.object({
   description: z.string().max(120),
   previous: z.string().array().optional(),
   limit: z.coerce.number().int().optional(),
-  rankingAlgorithm: z.enum(searchSortingAlgorithms).optional(),
+  sortingAlgorithm: z.enum(searchSortingAlgorithms).optional(),
   matchScoreWeight: z.coerce.number().int().min(0).max(100).optional(),
   recipe: z.string().optional(),
   category: z.string().optional(),


### PR DESCRIPTION
**Problem**
A naming mismatch (`rankingAlgorithm` vs `sortingAlgorithm`) causes the api to always return the default (`'popularity'`), even if a different algorithm is stored in the DB.

**Fix**
Replace all instances of `rankingAlgorithm` with `sortingAlgorithm`, which is the name used in the DB.

Also removed type definition `RankingAlgorithm` that appears to be unused.