### PR TITLE
Accessible image-based portion selection

### DIFF
--- a/apps/survey/src/components/prompts/partials/AsServedSelector.vue
+++ b/apps/survey/src/components/prompts/partials/AsServedSelector.vue
@@ -9,7 +9,7 @@
     <div class="label">
       <slot name="label" />
       <v-chip
-        v-if="label"
+        v-if="labelsEnabled && label"
         class="ma-1 ma-md-2 pa-3 pa-md-4 text-title-large font-weight-bold border-info-1"
         color="info"
       >
@@ -38,6 +38,7 @@
               :disabled="isLessWeightFactorActive"
               icon
               size="x-large"
+              tabindex="-1"
               :title="$t(`prompts.asServed.${type}.less`)"
             >
               <v-icon color="white" size="large">
@@ -55,7 +56,12 @@
         lg
         sm="2"
       >
-        <v-card @click="setSelection(idx)">
+        <v-card
+          :aria-label="labels.objects?.[idx]"
+          tabindex="0"
+          @click="setSelection(idx)"
+          @keydown="onKeydown($event, idx)"
+        >
           <v-img cover :src="images.thumbnailUrl" />
         </v-card>
       </v-col>
@@ -74,6 +80,7 @@
               :disabled="isMoreWeightFactorActive"
               icon
               size="x-large"
+              tabindex="-1"
               :title="$t(`prompts.asServed.${type}.more`)"
             >
               <v-icon color="white" size="large">
@@ -148,7 +155,7 @@ const { imageData: asServedData } = useFetchImageData<AsServedSetResponse>({
     initSelection();
   },
 });
-const { labels } = useLabels(props, { type: 'asServed', data: asServedData });
+const { labels, labelsEnabled } = useLabels(props, { type: 'asServed', data: asServedData });
 const label = computed(() => {
   if (objectIdx.value === undefined || !asServedData.value)
     return null;
@@ -370,6 +377,13 @@ function confirm() {
 
   emit('confirm');
 };
+
+function onKeydown(e: KeyboardEvent, idx: number) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    setSelection(idx);
+  }
+}
 </script>
 
 <style lang="scss" scoped>

--- a/apps/survey/src/components/prompts/partials/ImageMapSelector.vue
+++ b/apps/survey/src/components/prompts/partials/ImageMapSelector.vue
@@ -43,7 +43,7 @@
         <div class="label">
           <slot name="label">
             <v-chip
-              v-if="label"
+              v-if="labelsEnabled && label"
               class="ma-1 ma-md-2 pa-3 pa-md-4 text-title-large font-weight-bold border-info-1"
               color="info"
             >
@@ -58,11 +58,15 @@
           <polygon
             v-for="(object, idx) in objects"
             :key="idx"
+            :aria-label="labels.objects?.[idx]"
             class="guide-drawer-polygon"
             :class="{ active: idx === index }"
             :points="object.polygon"
+            role="image"
+            tabindex="0"
             @click.stop="select(idx, object.id)"
-            @keypress.stop="select(idx, object.id)"
+            @keydown.enter.prevent="select(idx, object.id)"
+            @keydown.space.prevent="select(idx, object.id)"
             @mouseleave="hoverIndex = undefined"
             @mouseover="hoverIndex = idx"
           />
@@ -116,6 +120,10 @@ const props = defineProps({
   labels: {
     type: Object as PropType<{ image: string; objects: string[] }>,
     default: () => ({ image: '', objects: [] }),
+  },
+  labelsEnabled: {
+    type: Boolean,
+    default: false,
   },
 });
 
@@ -199,12 +207,14 @@ onMounted(() => {
         filter: url(#polygon-blur);
       }
 
-      &:hover {
+      &:hover,
+      &:focus {
         stroke-width: 8;
         stroke: variables.$info;
         stroke-linecap: round;
         stroke-linejoin: round;
         filter: url(#polygon-blur);
+        outline: none;
       }
     }
   }

--- a/apps/survey/src/components/prompts/partials/use-labels.ts
+++ b/apps/survey/src/components/prompts/partials/use-labels.ts
@@ -102,9 +102,6 @@ export function useLabels<P extends 'as-served-prompt' | 'cereal-prompt' | 'guid
   };
 
   const labels = computed(() => {
-    if (!labelsEnabled.value)
-      return { image: '', objects: [] };
-
     // @ts-expect-error - narrow down the type
     return resolveLabels[source.type](source.data.value);
   });

--- a/apps/survey/src/components/prompts/portion/DrinkScalePrompt.vue
+++ b/apps/survey/src/components/prompts/portion/DrinkScalePrompt.vue
@@ -39,6 +39,7 @@
               id: state.portionSize.containerId,
               index: state.portionSize.containerIndex,
               labels,
+              labelsEnabled,
             }"
             @confirm="confirmObject"
             @select="selectObject"
@@ -244,7 +245,7 @@ const imageMapUrl = computed(() => drinkwareSetData.value ? `portion-sizes/image
 const { imageData: imageMapData } = useFetchImageData<ImageMapResponse>({ url: imageMapUrl });
 
 const labelData = computed(() => ({ drinkwareSet: drinkwareSetData.value, imageMap: imageMapData.value }));
-const { labels } = useLabels(props, { type: 'drinkScale', data: labelData });
+const { labels, labelsEnabled } = useLabels(props, { type: 'drinkScale', data: labelData });
 
 const leftoversEnabled = computed(() => props.prompt.leftovers);
 

--- a/apps/survey/src/components/prompts/portion/GuideImagePrompt.vue
+++ b/apps/survey/src/components/prompts/portion/GuideImagePrompt.vue
@@ -39,6 +39,7 @@
               id: state.portionSize.objectId,
               index: state.portionSize.objectIndex,
               labels,
+              labelsEnabled,
             }"
             @confirm="confirmObject"
             @select="selectObject"
@@ -138,10 +139,10 @@ const { imageData } = useFetchImageData<GuideImageResponse>({
   },
 });
 
-const { labels } = useLabels(props, { type: 'guideImage', data: imageData });
+const { labels, labelsEnabled } = useLabels(props, { type: 'guideImage', data: imageData });
 
 const selectedFoodLabel = computed(() => {
-  if (!labels.value.objects.length || state.value.portionSize.objectIndex === undefined)
+  if (!labelsEnabled.value || !labels.value.objects.length || state.value.portionSize.objectIndex === undefined)
     return foodName.value;
 
   return labels.value.objects[state.value.portionSize.objectIndex] || foodName.value;

--- a/apps/survey/src/components/prompts/portion/MilkOnCerealPrompt.vue
+++ b/apps/survey/src/components/prompts/portion/MilkOnCerealPrompt.vue
@@ -39,6 +39,7 @@
               id: state.portionSize.bowlId,
               index: state.portionSize.bowlIndex,
               labels: bowlLabels,
+              labelsEnabled,
             }"
             @confirm="confirmBowl"
             @select="selectBowl"
@@ -67,6 +68,7 @@
               id: state.portionSize.milkLevelId,
               index: state.portionSize.milkLevelIndex,
               labels: milkLevelLabels,
+              labelsEnabled,
             }"
             @confirm="confirmMilk"
             @select="selectMilk"
@@ -148,7 +150,7 @@ const { imageData: bowlImageMap } = useFetchImageData<ImageMapResponse>({
     }
   },
 });
-const { labels: bowlLabels } = useLabels(props, { type: 'imageMap', data: bowlImageMap });
+const { labels: bowlLabels, labelsEnabled } = useLabels(props, { type: 'imageMap', data: bowlImageMap });
 
 const bowl = computed(() => state.value.portionSize.bowl ?? undefined);
 const milkLevelImageMapId = computed(() => {

--- a/apps/survey/src/components/prompts/portion/PizzaPrompt.vue
+++ b/apps/survey/src/components/prompts/portion/PizzaPrompt.vue
@@ -205,8 +205,6 @@ const imageMapIds = computed(() => ({
 }));
 
 const labelsEnabled = computed(() => !!(props.prompt.imageMap.labels && !!parameters.value.labels));
-console.log(props.prompt.imageMap.labels);
-console.log(parameters.value);
 const imageMapLabels = computed(() => {
   return Object.keys(imageMapIds.value).reduce<Record<PizzaImageMap, { image: string; objects: string[] }>>(
     (acc, key) => {

--- a/apps/survey/src/components/prompts/portion/PizzaPrompt.vue
+++ b/apps/survey/src/components/prompts/portion/PizzaPrompt.vue
@@ -204,7 +204,7 @@ const imageMapIds = computed(() => ({
   slice: sliceImageMapId.value,
 }));
 
-const labelsEnabled = computed(() => props.prompt.imageMap.labels && !!parameters.value.labels);
+const labelsEnabled = computed(() => !!(props.prompt.imageMap.labels && !!parameters.value.labels));
 console.log(props.prompt.imageMap.labels);
 console.log(parameters.value);
 const imageMapLabels = computed(() => {

--- a/apps/survey/src/components/prompts/portion/PizzaPrompt.vue
+++ b/apps/survey/src/components/prompts/portion/PizzaPrompt.vue
@@ -35,6 +35,7 @@
               id: state.portionSize.type.id,
               index: state.portionSize.type.index,
               labels: imageMapLabels.type,
+              labelsEnabled,
             }"
             @confirm="confirmType('type')"
             @select="(idx, id) => selectType('type', idx, id)"
@@ -57,6 +58,7 @@
               id: state.portionSize.thickness.id,
               index: state.portionSize.thickness.index,
               labels: imageMapLabels.thickness,
+              labelsEnabled,
             }"
             @confirm="confirmType('thickness')"
             @select="(idx, id) => selectType('thickness', idx, id)"
@@ -80,6 +82,7 @@
               id: state.portionSize.slice.id,
               index: state.portionSize.slice.index ? state.portionSize.slice.index - 1 : undefined,
               labels: imageMapLabels.slice,
+              labelsEnabled,
             }"
             @confirm="confirmType('slice')"
             @select="(idx, id) => selectType('slice', idx + 1, id)"
@@ -202,15 +205,9 @@ const imageMapIds = computed(() => ({
 }));
 
 const labelsEnabled = computed(() => props.prompt.imageMap.labels && !!parameters.value.labels);
+console.log(props.prompt.imageMap.labels);
+console.log(parameters.value);
 const imageMapLabels = computed(() => {
-  if (!labelsEnabled.value) {
-    return {
-      type: { image: '', objects: [] },
-      thickness: { image: '', objects: [] },
-      slice: { image: '', objects: [] },
-    };
-  }
-
   return Object.keys(imageMapIds.value).reduce<Record<PizzaImageMap, { image: string; objects: string[] }>>(
     (acc, key) => {
       const pizzaType = key as PizzaImageMap;


### PR DESCRIPTION
Currently, image-based portion selection in intake24 is not accessible to those using a screenreader. This update fixes that by adding keyboard navigability and `aria-label`s to each image, which will be read by a screenreader.

`aria-label`s are generated using the existing label system. These labels are now fetched unconditionally. `labelsEnabled` still controls label visibility.